### PR TITLE
Fixed a bug introduced in the last refactor of the run script.

### DIFF
--- a/transcrypt/development/continuous_integration/run
+++ b/transcrypt/development/continuous_integration/run
@@ -69,7 +69,7 @@ fi
 XVFB_PID=$(ps -e -o pid,cmd | \
            grep "[x]vfb-run -a firefox" | \
            head -n 1 | \
-           grep -o " \([[:digit:]]*\) ")
+           grep -o -m 1 "\([[:digit:]]*\) ")
 
 # Get the Process Group ID for xvfb-run, the parent of a
 # group of process that run under it


### PR DESCRIPTION
OK - very sorry about this but I think there was a small bug introduced into the last refactor. It was not capture the XVFB PID appropriate which caused it achieve the desired function. This patch should fix that. 
