### PR TITLE
Autotester Browser View Update #2

### DIFF
--- a/transcrypt/modules/org/transcrypt/autotester/__init__.py
+++ b/transcrypt/modules/org/transcrypt/autotester/__init__.py
@@ -59,7 +59,7 @@ def getFileLocation():
 		# This regex splits the string coming from the javascript
 		# stacktrace so that we can connect the file and line number
 		# runTests (http://localhost:8080/run/autotest.js:3159:8)
-		#  func       URL                     filename    lineno:colno
+		#  func	      URL		      filename	  lineno:colno
 		# Group 1 = function
 		# Group 2 & 3 = protocol and hostname
 		# Group 4 = Path on this host (filename is at the end)
@@ -204,7 +204,7 @@ class AutoTester:
 		    overflow-x: auto;
 		  }
 		  .exc-header {
-            color: red;
+	    color: red;
 		  }
 		</style>
 		"""
@@ -265,6 +265,7 @@ class AutoTester:
 		row = table.insertRow(-1);
 		if ( testItem != refItem ):
 			row.classList.add(self.faultRowClass)
+			refPos = "!!!" + refPos
 
 		# Populate the Row
 		cpy_pos = row.insertCell(0)


### PR DESCRIPTION
Hi, 

As we discussed in the last PR for the autotester browser view, the latest HTML generation has a couple of short comings: 

1. Lack of ability to quickly search for tests with errors ("!!!" prefix missing)
2. Ability to expand/contract portions of the table

This PR fixes both of these short comings. I currently have it setup to collapse by default any module where all tests successfully completed. The user can then expand or collapse by clicking on the blue header for that module. 

Note that the code in this file is getting pretty spaghetti-like. It could use a code cleanup but for right now I don't want to spend any more time on it. 