### PR TITLE
Initial Regular Expression Integration

### DIFF
--- a/transcrypt/development/automated_tests/re/autotest.py
+++ b/transcrypt/development/automated_tests/re/autotest.py
@@ -1,0 +1,11 @@
+import org.transcrypt.autotester
+
+import basic_pyre
+import basic_jsre
+
+autoTester = org.transcrypt.autotester.AutoTester ()
+
+autoTester.run (basic_jsre, 'Basic JS RE Tests')
+autoTester.run (basic_pyre, 'Basic Python RE Tests')
+
+autoTester.done ()

--- a/transcrypt/development/automated_tests/re/basic_jsre.py
+++ b/transcrypt/development/automated_tests/re/basic_jsre.py
@@ -1,0 +1,30 @@
+from org.transcrypt.stubs.browser import __pragma__
+import re
+__pragma__("skip")
+re.J = (1<<19)
+re.JSSTRICT = re.J
+__pragma__("noskip")
+
+from basictests import *
+
+def run (test):
+	""" basic tests of the re engine. The point is to
+	exercise most of the methods to make sure they behave as
+	expected. These tests are expected to provide exhaustive
+	coverage of the regex engine.
+	"""
+	checkFlagsExist(test)
+	escapeTests(test)
+	checkMatchProperties(test, re.JSSTRICT)
+	checkRegexProperties(test, re.JSSTRICT)
+
+	checkIgnoreCase(test, re.JSSTRICT)
+
+	checkSearchWithGroups(test, re.JSSTRICT)
+	checkMatchOps(test, re.JSSTRICT)
+	checkFullMatchOps(test, re.JSSTRICT)
+	checkFindAllOps(test, re.JSSTRICT)
+	checkSplitOps(test, re.JSSTRICT)
+	checkSubOps(test, re.JSSTRICT)
+	checkSyntaxErrors(test, re.JSSTRICT)
+	checkFindIter(test, re.JSSTRICT)

--- a/transcrypt/development/automated_tests/re/basic_pyre.py
+++ b/transcrypt/development/automated_tests/re/basic_pyre.py
@@ -1,0 +1,31 @@
+# File: basic_pyre.py
+#
+# This file contains the basic regex tests run on the
+# python translated regex expressions.
+#
+
+from org.transcrypt.stubs.browser import __pragma__
+import re
+from basictests import *
+
+def run (test):
+	""" basic tests of the re engine. The point is to
+	exercise most of the methods to make sure they behave as
+	expected. These tests are expected to provide exhaustive
+	coverage of the regex engine.
+	"""
+	checkFlagsExist(test)
+
+	escapeTests(test)
+	checkMatchProperties(test)
+	checkRegexProperties(test)
+
+	checkIgnoreCase(test)
+
+	checkSearchWithGroups(test)
+	checkMatchOps(test)
+	checkFullMatchOps(test)
+	checkFindAllOps(test)
+	checkSplitOps(test)
+	checkSubOps(test)
+	checkSyntaxErrors(test)

--- a/transcrypt/development/automated_tests/re/basictests.py
+++ b/transcrypt/development/automated_tests/re/basictests.py
@@ -1,0 +1,220 @@
+
+from org.transcrypt.stubs.browser import __pragma__
+import re
+__pragma__("skip")
+re.J = (1<<19)
+re.JSSTRICT = re.J
+__pragma__("noskip")
+
+testStr1 = "There,is,No,Time"
+testStr2 = "som[23] In[23423] the[34].asd[934].234."
+testStr3 = "s(43) d(03) asdfasd dsfsd(3) sd"
+testStr4 = "Were an apple like an orange then apple orange no appleorange"
+
+def checkMatchProperties(test, flags = 0):
+	""" This test checks that properties on the match
+	are reported correctly, and that they are read-only
+	"""
+	result = re.search(",", testStr1, flags)
+	if ( result is not None ):
+		test.check( result.pos )
+		test.check( result.endpos )
+		test.check( result.group() )
+		test.check( result.group(0) )
+		test.check( result.string )
+
+		# Check readonly props of match
+		def assignPos():
+			result.pos = 1
+		test.check(test.expectException(assignPos))
+		def assignEndPos():
+			result.endpos = 1
+		test.check(test.expectException(assignEndPos))
+		def assignRe():
+			result.re = "asdfasdf"
+		test.check(test.expectException(assignRe))
+		def assignStr():
+			result.string = "asdf"
+		test.check(test.expectException(assignStr))
+		def assignLastGroup():
+			result.lastgroup = "asdfasdf"
+		test.check(test.expectException(assignLastGroup))
+		def assignLastIndex():
+			result.lastindex = 33
+		test.check(test.expectException(assignLastIndex))
+	else:
+		test.checkPad("NULL", 11)
+
+
+def checkRegexProperties(test, flags = 0):
+	""" This test checks that the appropriate properties
+	exist on the Regex object and that these properties
+	are read-only.
+	"""
+	r = re.compile(",", flags)
+	if ( r is not None ):
+		test.check( r.groups )
+		test.check( r.pattern )
+		test.check( r.flags )
+		test.check( r.groupindex )
+		# Check Read-only props on regex object
+		def assignPattern():
+			r.pattern = "asdfasdf"
+		test.check(
+			test.expectException(assignPattern)
+		)
+		def assignFlags():
+			r.flags = "wer"
+		test.check(
+			test.expectException(assignFlags)
+		)
+		def assignGroups():
+			r.groups = 1
+		test.check(
+			test.expectException(assignGroups)
+		)
+		def assignGroupIndex():
+			r.groupindex = 34
+		test.check(
+			test.expectException(assignGroupIndex)
+		)
+	else:
+		test.checkPad("NULL", 8)
+
+def checkFlagsExist(test):
+	test.check(re.T)
+	test.check(re.I)
+	test.check(re.IGNORECASE)
+	test.check(re.M)
+	test.check(re.MULTILINE)
+	test.check(re.S)
+	test.check(re.DOTALL)
+	test.check(re.U)
+	test.check(re.UNICODE)
+	test.check(re.X)
+	test.check(re.VERBOSE)
+	test.check(re.A)
+	test.check(re.ASCII)
+
+def escapeTests(test):
+	test.check(re.escape("buf[34]"))
+	test.check(re.escape("C:\\asdf\\wewer\\"))
+	test.check(re.escape("func(int a) { return(3)};"))
+
+def checkIgnoreCase(test, flags = 0):
+	test.check( re.search("as", testStr3, flags|re.I).pos )
+	test.check( re.search("as", testStr3, flags|re.I).endpos )
+	test.check( re.search("as", testStr3, flags|re.I).group() )
+	test.check( re.search("as", testStr3, flags|re.I).group(0) )
+	test.check( re.search("AS", testStr3, flags|re.I).pos )
+	test.check( re.search("AS", testStr3, flags|re.I).endpos )
+	test.check( re.search("AS", testStr3, flags|re.I).group() )
+	test.check( re.search("AS", testStr3, flags|re.I).group(0) )
+
+def checkSearchWithGroups(test, flags = 0):
+	r = "\\[([\\d]+)\\]"
+	test.check( re.compile(r, flags).groups )
+	test.check( re.search(r, testStr2, flags).pos)
+	test.check( re.search(r, testStr2, flags).endpos)
+	test.check( re.search(r, testStr2, flags).groups())
+	test.check( re.search(r, testStr2, flags).group())
+	test.check( re.search(r, testStr2, flags).group(0))
+	test.check( re.search(r, testStr2, flags).group(1))
+	test.check( re.search(r, testStr2, flags).start())
+	test.check( re.search(r, testStr2, flags).start(0))
+	test.check( re.search(r, testStr2, flags).start(1))
+	test.check( re.search(r, testStr2, flags).end())
+	test.check( re.search(r, testStr2, flags).end(0))
+	test.check( re.search(r, testStr2, flags).end(1))
+	test.check( re.search(r, testStr2, flags).span())
+	test.check( re.search(r, testStr2, flags).span(0))
+	test.check( re.search(r, testStr2, flags).span(1))
+	test.check( re.search(r, testStr2, flags).lastgroup)
+	test.check( re.search(r, testStr2, flags).lastindex)
+
+	for i in range(2,50):
+		test.check(
+			test.expectException(lambda: re.search(',', testStr1, flags).group(1))
+		)
+
+
+def checkMatchOps(test, flags = 0):
+	test.check( re.match("asdf", "asdf", flags).pos )
+	test.check( re.match(r"asdf", "asdf", flags).endpos )
+	test.check( re.match("asdf", "asdf", flags).groups() )
+	test.check( re.match("a", "asdf", flags).pos )
+	test.check( re.match("a", "asdf", flags).endpos )
+	test.check( re.match("a", "asdf", flags).groups() )
+	test.check( (re.match("s", "asdf", flags) is None) )
+	test.check( (re.match(r"^s", "asdf", flags) is None) )
+	test.check( (re.compile("^s", flags).match("asdf", 1) is None) )
+
+def checkFullMatchOps(test, flags = 0):
+	test.check( (re.fullmatch("asdf", "asdf", flags).pos))
+	test.check( (re.fullmatch("asdf", "asdf", flags).endpos))
+	test.check( (re.fullmatch("as", "asdf", flags) is None))
+	test.check( (re.fullmatch("q", "asdf", flags) is None))
+	test.check( (re.compile("o[gh]", flags).fullmatch("dog") is None))
+	test.check( (re.compile("o[gh]", flags).fullmatch("ogre") is None))
+	test.check( re.compile("o[gh]", flags).fullmatch("doggie",1,3).pos)
+
+def checkFindAllOps(test, flags = 0):
+	test.check(re.findall(",", testStr1, flags)) # No Caps
+	test.check(re.findall("\\[([\\d]+)\\]", testStr2, flags)) # 1 Cap
+	r = "([^\d\s]+\\(([\d]+)\\))"
+	test.check(re.compile(r, flags).groups)
+	test.check(re.findall(r, testStr3, flags)) # 2 Caps
+
+def checkSplitOps(test, flags = 0):
+	test.check(re.split(",", testStr1, flags))
+
+	test.check(re.split("(apple|orange)",testStr4, flags))
+	test.check(re.split("\\[([\\d]+)\\]", testStr2, flags))
+	r = re.compile(",", flags)
+	test.check(r.split(testStr1, 0))
+	test.check(r.split(testStr1, 1))
+	test.check(r.split(testStr1, 2))
+	test.check(r.split(testStr1, 3))
+	test.check(r.split(testStr1, 4))
+
+	r = re.compile("\\[([\\d]+)\\]", flags)
+	test.check(r.split(testStr2,0))
+	test.check(r.split(testStr2,1))
+	test.check(r.split(testStr2,2))
+	test.check(r.split(testStr2,3))
+	test.check(r.split(testStr2,4))
+
+def checkSubOps(test, flags = 0):
+	def dashrepl(matchobj):
+		if matchobj.group(0) == '-':
+			return ' '
+		else:
+			return '-'
+	test.check(re.sub('-{1,2}', dashrepl, 'pro----gram-files',0, flags))
+	test.check(re.sub('-{1,2}', '4', 'pro----gram-files',0, flags))
+	test.check(re.subn('-{1,2}', dashrepl, 'pro----gram-files',0,flags))
+	test.check(re.subn('-{1,2}', '4', 'pro----gram-files',0,flags))
+
+def checkSyntaxErrors(test, flags = 0):
+	test.check(test.expectException( lambda: re.compile(r')', flags)))
+	test.check(test.expectException( lambda: re.compile("a\\", flags)))
+	test.check(test.expectException( lambda: re.compile(r'a[b', flags)))
+	test.check(test.expectException( lambda: re.compile(r'(abc', flags)))
+	test.check(test.expectException( lambda: re.compile(r')(', flags)))
+	test.check(test.expectException( lambda: re.compile(r'))', flags)))
+	test.check(test.expectException( lambda: re.compile(r'a[b-a]', flags)))
+	test.check(test.expectException( lambda: re.compile(r'*a', flags)))
+
+def checkFindIter(test, flags = 0):
+	""" Test the finditer method
+	"""
+	p = "\\[([\\d]+)\\]"
+	r = re.compile(p, flags)
+	test.check( r.groups )
+
+	iret = r.finditer(testStr2)
+	for m in iret:
+		test.check(m.pos)
+		test.check(m.endpos)
+		test.check(m.string)
+		test.check(m.lastindex)

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -3,49 +3,53 @@
 	// They can't do that itself, because they're regular Python modules
 	// The compiler recognizes their names and generates them inline rather than nesting them
 	// In this way it isn't needed to import them everywhere
-	 	
+
 	// __base__
-	
+
 	__nest__ (__all__, '', __init__ (__all__.org.transcrypt.__base__));
 	var __envir__ = __all__.__envir__;
 
 	// __standard__
-	
+
 	__nest__ (__all__, '', __init__ (__all__.org.transcrypt.__standard__));
-	
+
 	var Exception = __all__.Exception;
 	var IterableError = __all__.IterableError;
 	var StopIteration = __all__.StopIteration;
 	var ValueError = __all__.ValueError;
+	var KeyError = __all__.KeyError;
 	var AssertionError = __all__.AssertionError;
-	
+	var NotImplementedError = __all__.NotImplementedError;
+	var IndexError = __all__.IndexError;
+	var AttributeError = __all__.AttributeError;
+
 	var __sort__ = __all__.__sort__;
 	var sorted = __all__.sorted;
-	
+
 	var map = __all__.map;
 	var filter = __all__.filter;
-	
+
 __pragma__ ('ifdef', '__complex__')
 	var complex = __all__.complex;
 __pragma__ ('endif')
 	__all__.print = __all__.__terminal__.print;
 	__all__.input = __all__.__terminal__.input;
-	
+
 	var __terminal__ = __all__.__terminal__;
 	var print = __all__.print;
 	var input = __all__.input;
 
 	// Complete __envir__, that was created in __base__, for non-stub mode
 	__envir__.executor_name = __envir__.transpiler_name;
-	
+
 	// Make make __main__ available in browser
 	var __main__ = {__file__: ''};
 	__all__.main = __main__;
-	
+
 	// Define current exception, there's at most one exception in the air at any time
 	var __except__ = null;
 	__all__.__except__ = __except__;
-		
+
 	// Define recognizable dictionary for **kwargs parameter
 	var __kwargdict__ = function (anObject) {
 		anObject.__class__ = __kwargdict__;	// This class needs no __name__
@@ -53,7 +57,7 @@ __pragma__ ('endif')
 		return anObject;
 	}
 	__all__.___kwargdict__ = __kwargdict__;
-	
+
 	// Property installer function, no member since that would bloat classes
 	var property = function (getter, setter) {	// Returns a property descriptor rather than a property
 		if (!setter) {	// ??? Make setter optional instead of dummy?
@@ -62,16 +66,16 @@ __pragma__ ('endif')
 		return {get: function () {return getter (this)}, set: function (value) {setter (this, value)}, enumerable: true};
 	}
 	__all__.property = property;
-	
+
 	// Assert function, call to it only generated when compiling with --dassert option
 	function assert (condition, message) {	// Message may be undefined
 		if (!condition) {
 			throw AssertionError (message, new Error ());
 		}
 	}
-	
+
 	__all__.assert = assert;
-	
+
 	var __merge__ = function (object0, object1) {
 		var result = {};
 		for (var attrib in object0) {
@@ -83,9 +87,9 @@ __pragma__ ('endif')
 		return result;
 	}
 	__all__.__merge__ = __merge__;
-	
+
 	// Manipulating attributes by name
-	
+
 	var dir = function (obj) {
 		var aList = [];
 		for (var aKey in obj) {
@@ -94,29 +98,29 @@ __pragma__ ('endif')
 		aList.sort ();
 		return aList;
 	}
-	
+
 	var setattr = function (obj, name, value) {
 		obj [name] = value;
 	};
-		
+
 	__all__.setattr = setattr;
-	
+
 	var getattr = function (obj, name) {
 		return obj [name];
 	};
-	
+
 	__all__.getattr= getattr
-	
+
 	var hasattr = function (obj, name) {
 		return name in obj;
 	};
 	__all__.hasattr = hasattr;
-	
+
 	var delattr = function (obj, name) {
 		delete obj [name];
 	};
 	__all__.delattr = (delattr);
-	
+
 	// The __in__ function, used to mimic Python's 'in' operator
 	// In addition to CPython's semantics, the 'in' operator is also allowed to work on objects, avoiding a counterintuitive separation between Python dicts and JavaScript objects
 	// In general many Transcrypt compound types feature a deliberate blend of Python and JavaScript facilities, facilitating efficient integration with JavaScript libraries
@@ -134,13 +138,13 @@ __pragma__ ('endif')
 		}
 	}
 	__all__.__in__ = __in__;
-	
+
 	// Find out if an attribute is special
 	var __specialattrib__ = function (attrib) {
 		return (attrib.startswith ('__') && attrib.endswith ('__')) || attrib == 'constructor' || attrib.startswith ('py_');
 	}
 	__all__.__specialattrib__ = __specialattrib__;
-		
+
 	// Len function for any object
 	var len = function (anObject) {
 		if (anObject) {
@@ -165,11 +169,11 @@ __pragma__ ('endif')
 	__all__.len = len;
 
 	// General conversions
-	
+
 	function __i__ (any) {	//	Conversion to iterable
-		return py_typeof (any) == dict ? any.py_keys () : any;		
+		return py_typeof (any) == dict ? any.py_keys () : any;
 	}
-	
+
 	function __t__ (any) {	// Conversion to truthyness, __ ([1, 2, 3]) returns [1, 2, 3], needed for nonempty selection: l = list1 or list2]
 		return (['boolean', 'number'] .indexOf (typeof any) >= 0 || any instanceof Function || len (any)) ? any : false;
 		// JavaScript functions have a length attribute, denoting the number of parameters
@@ -177,13 +181,13 @@ __pragma__ ('endif')
 		// By the term 'any instanceof Function' we make sure that Python objects aren't rejected when their length equals zero
 	}
 	__all__.__t__ = __t__;
-	
+
 	var bool = function (any) {		// Always truly returns a bool, rather than something truthy or falsy
 		return !!__t__ (any);
 	}
 	bool.__name__ = 'bool'			// So it can be used as a type with a name
 	__all__.bool = bool;
-	
+
 	var float = function (any) {
 		if (any == 'inf') {
 			return Infinity;
@@ -200,13 +204,13 @@ __pragma__ ('endif')
 	}
 	float.__name__ = 'float'
 	__all__.float = float;
-	
+
 	var int = function (any) {
 		return float (any) | 0
 	}
 	int.__name__ = 'int';
 	__all__.int = int;
-	
+
 	var py_typeof = function (anObject) {
 		var aType = typeof anObject;
 		if (aType == 'object') {	// Directly trying '__class__ in anObject' turns out to wreck anObject in Chrome if its a primitive
@@ -227,8 +231,8 @@ __pragma__ ('endif')
 		}
 	}
 	__all__.py_typeof = py_typeof;
-	
-	var isinstance = function (anObject, classinfo) {		
+
+	var isinstance = function (anObject, classinfo) {
 		function isA (queryClass) {
 			if (queryClass == classinfo) {
 				return true;
@@ -240,7 +244,7 @@ __pragma__ ('endif')
 			}
 			return false;
 		}
-		
+
 		if (classinfo instanceof Array) {	// Assume in most cases it isn't, then making it recursive rather than two functions saves a call
 __pragma__ ('ifdef', '__esv6__')
 			for (let aClass of classinfo) {
@@ -254,7 +258,7 @@ __pragma__ ('endif')
 			}
 			return false;
 		}
-		
+
 		try {					// Most frequent use case first
 			return '__class__' in anObject ? isA (anObject.__class__) : anObject instanceof classinfo;
 		}
@@ -264,7 +268,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.isinstance = isinstance;
-	
+
 	// Repr function uses __repr__ method, then __str__, then toString
 	var repr = function (anObject) {
 		try {
@@ -285,12 +289,12 @@ __pragma__ ('endif')
 						for (var attrib in anObject) {
 							if (!__specialattrib__ (attrib)) {
 								if (attrib.isnumeric ()) {
-									var attribRepr = attrib;				// If key can be interpreted as numerical, we make it numerical 
+									var attribRepr = attrib;				// If key can be interpreted as numerical, we make it numerical
 								}											// So we accept that '1' is misrepresented as 1
 								else {
 									var attribRepr = '\'' + attrib + '\'';	// Alpha key in dict
 								}
-								
+
 								if (comma) {
 									result += ', ';
 								}
@@ -306,7 +310,7 @@ __pragma__ ('endif')
 							}
 						}
 						result += '}';
-						return result;					
+						return result;
 					}
 					else {
 						return typeof anObject == 'boolean' ? anObject.toString () .capitalize () : anObject.toString ();
@@ -321,7 +325,7 @@ __pragma__ ('endif')
 		}
 	}
 	__all__.repr = repr;
-	
+
 	// Char from Unicode or ASCII
 	var chr = function (charCode) {
 		return String.fromCharCode (charCode);
@@ -333,15 +337,15 @@ __pragma__ ('endif')
 		return aChar.charCodeAt (0);
 	}
 	__all__.org = ord;
-	
+
 	// Maximum of n numbers
 	var max = Math.max;
 	__all__.max = max;
-	
+
 	// Minimum of n numbers
 	var min = Math.min;
 	__all__.min = min;
-	
+
 	// Absolute value
 __pragma__ ('ifdef', '__complex__')
 	var abs = function (x) {
@@ -356,29 +360,29 @@ __pragma__ ('else')
 	var abs = Math.abs;
 	__all__.abs = abs;
 __pragma__ ('endif')
-	
+
 	// Bankers rounding
 	var round = function (number, ndigits) {
 		if (ndigits) {
 			var scale = Math.pow (10, ndigits);
 			number *= scale;
 		}
-			
+
 		var rounded = Math.round (number);
 		if (rounded - number == 0.5 && rounded % 2) {	// Has rounded up to odd, should have rounded down to even
 			rounded -= 1;
 		}
-			
+
 		if (ndigits) {
 			rounded /= scale;
 		}
-		
+
 		return rounded
  	}
 	__all__.round = round;
-		
+
 	// BEGIN unified iterator model
-	
+
 	function __jsUsePyNext__ () {		// Add as 'next' method to make Python iterator JavaScript compatible
 		try {
 			var result = this.__next__ ();
@@ -388,7 +392,7 @@ __pragma__ ('endif')
 			return {value: undefined, done: true};
 		}
 	}
-	
+
 	function __pyUseJsNext__ () {		// Add as '__next__' method to make JavaScript iterator Python compatible
 		var result = this.next ();
 		if (result.done) {
@@ -398,7 +402,7 @@ __pragma__ ('endif')
 			return result.value;
 		}
 	}
-	
+
 	function py_iter (iterable) {					// Alias for Python's iter function, produces a universal iterator / iterable, usable in Python and JavaScript
 		if (typeof iterable == 'string' || '__iter__' in iterable) {	// JavaScript Array or string or Python iterable (string has no 'in')
 			var result = iterable.__iter__ ();							// Iterator has a __next__
@@ -424,7 +428,7 @@ __pragma__ ('endif')
 		result [Symbol.iterator] = function () {return result;};
 		return result;
 	}
-	
+
 	function py_next (iterator) {				// Called only in a Python context, could receive Python or JavaScript iterator
 		try {									// Primarily assume Python iterator, for max speed
 			var result = iterator.__next__ ();
@@ -437,7 +441,7 @@ __pragma__ ('endif')
 			else {
 				return result.value;
 			}
-		}	
+		}
 		if (result == undefined) {
 			throw StopIteration (new Error ());
 		}
@@ -445,12 +449,12 @@ __pragma__ ('endif')
 			return result;
 		}
 	}
-		
+
 	function __PyIterator__ (iterable) {
 		this.iterable = iterable;
 		this.index = 0;
 	}
-	
+
 	__PyIterator__.prototype.__next__ = function () {
 		if (this.index < this.iterable.length) {
 			return this.iterable [this.index++];
@@ -459,7 +463,7 @@ __pragma__ ('endif')
 			throw StopIteration (new Error ());
 		}
 	}
-	
+
 	function __JsIterator__ (iterable) {
 		this.iterable = iterable;
 		this.index = 0;
@@ -473,9 +477,9 @@ __pragma__ ('endif')
 			return {value: undefined, done: true};
 		}
 	}
-	
+
 	// END unified iterator model
-	
+
 	// Reversed function for arrays
 	var py_reversed = function (iterable) {
 		iterable = iterable.slice ();
@@ -483,7 +487,7 @@ __pragma__ ('endif')
 		return iterable;
 	}
 	__all__.py_reversed = py_reversed;
-	
+
 	// Zip method for arrays
 	var zip = function () {
 		var args = [] .slice.call (arguments);
@@ -503,7 +507,7 @@ __pragma__ ('endif')
 		);
 	}
 	__all__.zip = zip;
-	
+
 	// Range method, returning an array
 	function range (start, stop, step) {
 		if (stop == undefined) {
@@ -524,9 +528,9 @@ __pragma__ ('endif')
 		return result;
 	};
 	__all__.range = range;
-	
+
 	// Any, all and sum
-	
+
 __pragma__ ('ifdef', '__esv6__')
 	function any (iterable) {
 		for (let item of iterable) {
@@ -580,15 +584,15 @@ __pragma__ ('endif')
 	__all__.any = any;
 	__all__.all = all;
 	__all__.sum = sum;
-	
+
 	// Enumerate method, returning a zipped list
 	function enumerate (iterable) {
 		return zip (range (len (iterable)), iterable);
 	}
 	__all__.enumerate = enumerate;
-		
+
 	// Shallow and deepcopy
-	
+
 	function copy (anObject) {
 		if (anObject == null || typeof anObject == "object") {
 			return anObject;
@@ -604,7 +608,7 @@ __pragma__ ('endif')
 		}
 	}
 	__all__.copy = copy;
-	
+
 	function deepcopy (anObject) {
 		if (anObject == null || typeof anObject == "object") {
 			return anObject;
@@ -620,9 +624,9 @@ __pragma__ ('endif')
 		}
 	}
 	__all__.deepcopy = deepcopy;
-		
+
 	// List extensions to Array
-	
+
 	function list (iterable) {										// All such creators should be callable without new
 __pragma__ ('ifdef', '__esv6__')
 		var instance = iterable ? Array.from (iterable) : [];
@@ -635,7 +639,7 @@ __pragma__ ('endif')
 	__all__.list = list;
 	Array.prototype.__class__ = list;	// All arrays are lists (not only if constructed by the list ctor), unless constructed otherwise
 	list.__name__ = 'list';
-	
+
 	/*
 	Array.from = function (iterator) { // !!! remove
 		result = [];
@@ -645,14 +649,14 @@ __pragma__ ('endif')
 		return result;
 	}
 	*/
-	
+
 	Array.prototype.__iter__ = function () {return new __PyIterator__ (this);}
-	
+
 	Array.prototype.__getslice__ = function (start, stop, step) {
 		if (start < 0) {
 			start = this.length + start;
 		}
-		
+
 		if (stop == null) {
 			stop = this.length;
 		}
@@ -662,29 +666,29 @@ __pragma__ ('endif')
 		else if (stop > this.length) {
 			stop = this.length;
 		}
-			
+
 		var result = list ([]);
 		for (var index = start; index < stop; index += step) {
 			result.push (this [index]);
 		}
-		
+
 		return result;
 	}
-		
+
 	Array.prototype.__setslice__ = function (start, stop, step, source) {
 		if (start < 0) {
 			start = this.length + start;
 		}
-			
+
 		if (stop == null) {
 			stop = this.length;
 		}
 		else if (stop < 0) {
 			stop = this.length + stop;
 		}
-			
+
 		if (step == null) {	// Assign to 'ordinary' slice, replace subsequence
-			Array.prototype.splice.apply (this, [start, stop - start] .concat (source)) 
+			Array.prototype.splice.apply (this, [start, stop - start] .concat (source))
 		}
 		else {				// Assign to extended slice, replace designated items one by one
 			var sourceIndex = 0;
@@ -693,14 +697,14 @@ __pragma__ ('endif')
 			}
 		}
 	}
-	
+
 	Array.prototype.__repr__ = function () {
 		if (this.__class__ == set && !this.length) {
 			return 'set()';
 		}
-		
+
 		var result = !this.__class__ || this.__class__ == list ? '[' : this.__class__ == tuple ? '(' : '{';
-		
+
 		for (var index = 0; index < this.length; index++) {
 			if (index) {
 				result += ', ';
@@ -712,17 +716,17 @@ __pragma__ ('endif')
 				result += this [index] .toString ();
 			}
 		}
-		
+
 		if (this.__class__ == tuple && this.length == 1) {
 			result += ',';
 		}
-		
+
 		result += !this.__class__ || this.__class__ == list ? ']' : this.__class__ == tuple ? ')' : '}';;
 		return result;
 	};
-	
+
 	Array.prototype.__str__ = Array.prototype.__repr__;
-	
+
 	Array.prototype.append = function (element) {
 		this.push (element);
 	};
@@ -730,11 +734,11 @@ __pragma__ ('endif')
 	Array.prototype.clear = function () {
 		this.length = 0;
 	};
-	
+
 	Array.prototype.extend = function (aList) {
 		this.push.apply (this, aList);
 	};
-	
+
 	Array.prototype.insert = function (index, element) {
 		this.splice (index, 0, element);
 	};
@@ -750,7 +754,7 @@ __pragma__ ('endif')
 	Array.prototype.index = function (element) {
 		return this.indexOf (element)
 	};
-	
+
 	Array.prototype.py_pop = function (index) {
 		if (index == undefined) {
 			return this.pop ()	// Remove last element
@@ -758,19 +762,19 @@ __pragma__ ('endif')
 		else {
 			return this.splice (index, 1) [0];
 		}
-	};	
-	
+	};
+
 	Array.prototype.py_sort = function () {
 		__sort__.apply  (null, [this].concat ([] .slice.apply (arguments)));	// Can't work directly with arguments
 		// Python params: (iterable, key = None, reverse = False)
 		// py_sort is called with the Transcrypt kwargs mechanism, and just passes the params on to __sort__
 		// __sort__ is def'ed with the Transcrypt kwargs mechanism
 	};
-	
+
 	Array.prototype.__add__ = function (aList) {
 		return list (this.concat (aList))
 	}
-	
+
 	Array.prototype.__mul__ = function (scalar) {
 		var result = this;
 		for (var i = 1; i < scalar; i++) {
@@ -778,11 +782,11 @@ __pragma__ ('endif')
 		}
 		return result;
 	}
-	
+
 	Array.prototype.__rmul__ = Array.prototype.__mul__;
-		
+
 	// Tuple extensions to Array
-	
+
 	function tuple (iterable) {
 		var instance = iterable ? [] .slice.apply (iterable) : [];
 		instance.__class__ = tuple;	// Not all arrays are tuples
@@ -790,37 +794,37 @@ __pragma__ ('endif')
 	}
 	__all__.tuple = tuple;
 	tuple.__name__ = 'tuple';
-	
+
 	// Set extensions to Array
 	// N.B. Since sets are unordered, set operations will occasionally alter the 'this' array by sorting it
-		
+
 	function set (iterable) {
 		var instance = [];
 		if (iterable) {
 			for (var index = 0; index < iterable.length; index++) {
 				instance.add (iterable [index]);
 			}
-			
-			
+
+
 		}
 		instance.__class__ = set;	// Not all arrays are sets
 		return instance;
 	}
 	__all__.set = set;
 	set.__name__ = 'set';
-	
+
 	Array.prototype.__bindexOf__ = function (element) {	// Used to turn O (n^2) into O (n log n)
 	// Since sorting is lex, compare has to be lex. This also allows for mixed lists
-	
+
 		element += '';
-	
+
 		var mindex = 0;
 		var maxdex = this.length - 1;
-			 
+
 		while (mindex <= maxdex) {
 			var index = (mindex + maxdex) / 2 | 0;
 			var middle = this [index] + '';
-	 
+
 			if (middle < element) {
 				mindex = index + 1;
 			}
@@ -831,23 +835,23 @@ __pragma__ ('endif')
 				return index;
 			}
 		}
-	 
+
 		return -1;
 	}
-	
-	Array.prototype.add = function (element) {		
+
+	Array.prototype.add = function (element) {
 		if (this.indexOf (element) == -1) {	// Avoid duplicates in set
 			this.push (element);
 		}
 	};
-	
+
 	Array.prototype.discard = function (element) {
 		var index = this.indexOf (element);
 		if (index != -1) {
 			this.splice (index, 1);
 		}
 	};
-	
+
 	Array.prototype.isdisjoint = function (other) {
 		this.sort ();
 		for (var i = 0; i < other.length; i++) {
@@ -857,7 +861,7 @@ __pragma__ ('endif')
 		}
 		return true;
 	};
-	
+
 	Array.prototype.issuperset = function (other) {
 		this.sort ();
 		for (var i = 0; i < other.length; i++) {
@@ -867,11 +871,11 @@ __pragma__ ('endif')
 		}
 		return true;
 	};
-	
+
 	Array.prototype.issubset = function (other) {
 		return set (other.slice ()) .issuperset (this);	// Sort copy of 'other', not 'other' itself, since it may be an ordered sequence
 	};
-	
+
 	Array.prototype.union = function (other) {
 		var result = set (this.slice () .sort ());
 		for (var i = 0; i < other.length; i++) {
@@ -881,7 +885,7 @@ __pragma__ ('endif')
 		}
 		return result;
 	};
-	
+
 	Array.prototype.intersection = function (other) {
 		this.sort ();
 		var result = set ();
@@ -892,7 +896,7 @@ __pragma__ ('endif')
 		}
 		return result;
 	};
-	
+
 	Array.prototype.difference = function (other) {
 		var sother = set (other.slice () .sort ());
 		var result = set ();
@@ -903,13 +907,13 @@ __pragma__ ('endif')
 		}
 		return result;
 	};
-	
+
 	Array.prototype.symmetric_difference = function (other) {
 		return this.union (other) .difference (this.intersection (other));
 	};
-	
+
 	Array.prototype.py_update = function () {	// O (n)
-		var updated = [] .concat.apply (this.slice (), arguments) .sort ();		
+		var updated = [] .concat.apply (this.slice (), arguments) .sort ();
 		this.clear ();
 		for (var i = 0; i < updated.length; i++) {
 			if (updated [i] != updated [i - 1]) {
@@ -917,7 +921,7 @@ __pragma__ ('endif')
 			}
 		}
 	};
-	
+
 	Array.prototype.__eq__ = function (other) {	// Also used for list
 		if (this.length != other.length) {
 			return false;
@@ -925,7 +929,7 @@ __pragma__ ('endif')
 		if (this.__class__ == set) {
 			this.sort ();
 			other.sort ();
-		}	
+		}
 		for (var i = 0; i < this.length; i++) {
 			if (this [i] != other [i]) {
 				return false;
@@ -933,29 +937,29 @@ __pragma__ ('endif')
 		}
 		return true;
 	};
-	
+
 	Array.prototype.__ne__ = function (other) {	// Also used for list
 		return !this.__eq__ (other);
 	}
-		
+
 	Array.prototype.__le__ = function (other) {
 		return this.issubset (other);
 	}
-		
+
 	Array.prototype.__ge__ = function (other) {
 		return this.issuperset (other);
 	}
-		
+
 	Array.prototype.__lt__ = function (other) {
 		return this.issubset (other) && !this.issuperset (other);
 	}
-		
+
 	Array.prototype.__gt__ = function (other) {
 		return this.issuperset (other) && !this.issubset (other);
 	}
-	
+
 	// String extensions
-	
+
 	function str (stringable) {
 		try {
 			return stringable.__str__ ();
@@ -969,45 +973,45 @@ __pragma__ ('endif')
 			}
 		}
 	}
-	__all__.str = str;	
-	
+	__all__.str = str;
+
 	String.prototype.__class__ = str;	// All strings are str
 	str.__name__ = 'str';
-	
+
 	String.prototype.__iter__ = function () {new __PyIterator__ (this);}
-		
+
 	String.prototype.__repr__ = function () {
 		return (this.indexOf ('\'') == -1 ? '\'' + this + '\'' : '"' + this + '"') .py_replace ('\t', '\\t') .py_replace ('\n', '\\n');
 	};
-	
+
 	String.prototype.__str__ = function () {
 		return this;
 	};
-	
+
 	String.prototype.capitalize = function () {
 		return this.charAt (0).toUpperCase () + this.slice (1);
 	};
-	
+
 	String.prototype.endswith = function (suffix) {
 		return suffix == '' || this.slice (-suffix.length) == suffix;
 	};
-	
+
 	String.prototype.find  = function (sub, start) {
 		return this.indexOf (sub, start);
 	};
-	
+
 	String.prototype.__getslice__ = function (start, stop, step) {
 		if (start < 0) {
 			start = this.length + start;
 		}
-		
+
 		if (stop == null) {
 			stop = this.length;
 		}
 		else if (stop < 0) {
 			stop = this.length + stop;
 		}
-		
+
 		var result = '';
 		if (step == 1) {
 			result = this.substring (start, stop);
@@ -1019,7 +1023,7 @@ __pragma__ ('endif')
 		}
 		return result;
 	}
-	
+
 	// Since it's worthwhile for the 'format' function to be able to deal with *args, it is defined as a property
 	// __get__ will produce a bound function if there's something before the dot
 	// Since a call using *args is compiled to e.g. <object>.<function>.apply (null, args), the function has to be bound already
@@ -1030,9 +1034,9 @@ __pragma__ ('endif')
 	// Call memoizing is unattractive here, since every string would then have to hold a reference to a bound format method
 	Object.defineProperty (String.prototype, 'format', {
 		get: function () {return __get__ (this, function (self) {
-			var args = tuple ([] .slice.apply (arguments).slice (1));			
+			var args = tuple ([] .slice.apply (arguments).slice (1));
 			var autoIndex = 0;
-			return self.replace (/\{(\w*)\}/g, function (match, key) { 
+			return self.replace (/\{(\w*)\}/g, function (match, key) {
 				if (key == '') {
 					key = autoIndex++;
 				}
@@ -1052,34 +1056,34 @@ __pragma__ ('endif')
 		});},
 		enumerable: true
 	});
-	
+
 	String.prototype.isnumeric = function () {
 		return !isNaN (parseFloat (this)) && isFinite (this);
 	};
-	
+
 	String.prototype.join = function (strings) {
 __pragma__ ('ifdef', '__esv6__')
 		strings = Array.from (strings);	// Much faster than iterating through strings char by char
 __pragma__ ('endif')
 		return strings.join (this);
 	};
-	
+
 	String.prototype.lower = function () {
 		return this.toLowerCase ();
 	};
-	
+
 	String.prototype.py_replace = function (old, aNew, maxreplace) {
 		return this.split (old, maxreplace) .join (aNew);
 	};
-	
+
 	String.prototype.lstrip = function () {
 		return this.replace (/^\s*/g, '');
 	};
-	
+
 	String.prototype.rfind = function (sub, start) {
 		return this.lastIndexOf (sub, start);
 	};
-	
+
 	String.prototype.rsplit = function (sep, maxsplit) {	// Combination of general whitespace sep and positive maxsplit neither supported nor checked, expensive and rare
 		if (sep == undefined || sep == null) {
 			sep = /\s+/;
@@ -1088,7 +1092,7 @@ __pragma__ ('endif')
 		else {
 			var stripped = this;
 		}
-			
+
 		if (maxsplit == undefined || maxsplit == -1) {
 			return stripped.split (sep);
 		}
@@ -1103,11 +1107,11 @@ __pragma__ ('endif')
 			}
 		}
 	};
-	
+
 	String.prototype.rstrip = function () {
 		return this.replace (/\s*$/g, '');
 	};
-	
+
 	String.prototype.py_split = function (sep, maxsplit) {	// Combination of general whitespace sep and positive maxsplit neither supported nor checked, expensive and rare
 		if (sep == undefined || sep == null) {
 			sep = /\s+/
@@ -1116,7 +1120,7 @@ __pragma__ ('endif')
 		else {
 			var stripped = this;
 		}
-			
+
 		if (maxsplit == undefined || maxsplit == -1) {
 			return stripped.split (sep);
 		}
@@ -1130,19 +1134,19 @@ __pragma__ ('endif')
 			}
 		}
 	};
-	
+
 	String.prototype.startswith = function (prefix) {
 		return this.indexOf (prefix) == 0;
 	};
-	
+
 	String.prototype.strip = function () {
 		return this.trim ();
 	};
-		
+
 	String.prototype.upper = function () {
 		return this.toUpperCase ();
 	};
-	
+
 	String.prototype.__mul__ = function (scalar) {
 		var result = this;
 		for (var i = 1; i < scalar; i++) {
@@ -1150,13 +1154,13 @@ __pragma__ ('endif')
 		}
 		return result;
 	}
-	
+
 	String.prototype.__rmul__ = String.prototype.__mul__;
 
 __pragma__ ('ifdef', '__map__')
 
 	// Dict extensions to map (experimental)
-	
+
 	function dict (objectOrPairs) {
 		if (objectOrPairs instanceof Array) {	// It's undefined or an array of pairs
 			var instance = Map (objectOrPairs);
@@ -1170,47 +1174,47 @@ __pragma__ ('ifdef', '__map__')
 		else {													// It's a JavaScript object literal
 			var instance = objectOrPairs;
 		}
-	__all__.dict = dict;	
-	
+	__all__.dict = dict;
+
 __pragma__ ('else')
-		
+
 	// Dict extensions to object
-	
+
 	function __keys__ () {
 		var keys = []
 		for (var attrib in this) {
 			if (!__specialattrib__ (attrib)) {
 				keys.push (attrib);
-			}     
+			}
 		}
 		return keys;
 	}
-		
+
 	function __items__ () {
 		var items = []
 		for (var attrib in this) {
 			if (!__specialattrib__ (attrib)) {
 				items.push ([attrib, this [attrib]]);
-			}     
+			}
 		}
 		return items;
 	}
-		
+
 	function __del__ (key) {
 		delete this [key];
 	}
-	
+
 	function __clear__ () {
 		for (var attrib in this) {
 			delete this [attrib];
 		}
 	}
-	
+
 	function __getdefault__ (aKey, aDefault) {	// Each Python object already has a function called __get__, so we call this one __getdefault__
 		var result = this [aKey];
 		return result == undefined ? (aDefault == undefined ? null : aDefault) : result;
 	}
-	
+
 	function __setdefault__ (aKey, aDefault) {
 		var result = this [aKey];
 		if (result != undefined) {
@@ -1220,7 +1224,7 @@ __pragma__ ('else')
 		this [aKey] = val;
 		return val;
 	}
-	
+
 	function __pop__ (aKey, aDefault) {
 		var result = this [aKey];
 		if (result != undefined) {
@@ -1228,14 +1232,14 @@ __pragma__ ('else')
 			return result;
 		}
 		return aDefault;
-	}	
-	
+	}
+
 	function __update__ (aDict) {
 		for (var aKey in aDict) {
 			this [aKey] = aDict [aKey];
 		}
 	}
-	
+
 	function dict (objectOrPairs) {
 		if (!objectOrPairs || objectOrPairs instanceof Array) {	// It's undefined or an array of pairs
 			var instance = {};
@@ -1249,7 +1253,7 @@ __pragma__ ('else')
 		else {													// It's a JavaScript object literal
 			var instance = objectOrPairs;
 		}
-		
+
 		// Trancrypt interprets e.g. {aKey: 'aValue'} as a Python dict literal rather than a JavaScript object literal
 		// So dict literals rather than bare Object literals will be passed to JavaScript libraries
 		// Some JavaScript libraries call all enumerable callable properties of an object that's passed to them
@@ -1258,7 +1262,7 @@ __pragma__ ('else')
 		Object.defineProperty (instance, 'py_keys', {value: __keys__, enumerable: false});
 		Object.defineProperty (instance, '__iter__', {value: function () {new __PyIterator__ (this.py_keys ());}, enumerable: false});
 		Object.defineProperty (instance, Symbol.iterator, {value: function () {new __JsIterator__ (this.py_keys ());}, enumerable: false});
-		Object.defineProperty (instance, 'py_items', {value: __items__, enumerable: false});		
+		Object.defineProperty (instance, 'py_items', {value: __items__, enumerable: false});
 		Object.defineProperty (instance, 'py_del', {value: __del__, enumerable: false});
 		Object.defineProperty (instance, 'py_clear', {value: __clear__, enumerable: false});
 		Object.defineProperty (instance, 'py_get', {value: __getdefault__, enumerable: false});
@@ -1278,12 +1282,12 @@ __pragma__ ('endif')
 		this.__doc__ = docString;
 		return this;
 	}
-	
+
 	// Python classes, methods and functions are all translated to JavaScript functions
 	Object.defineProperty (Function.prototype, '__setdoc__', {value: __setdoc__, enumerable: false});
-		
+
 	// General operator overloading, only the ones that make most sense in matrix and complex operations
-	
+
 	var __neg__ = function (a) {
 		if (typeof a == 'object' && '__neg__' in a) {
 			return a.__neg__ ();
@@ -1291,14 +1295,14 @@ __pragma__ ('endif')
 		else {
 			return -a;
 		}
-	};  
+	};
 	__all__.__neg__ = __neg__;
-	
+
 	var __matmul__ = function (a, b) {
 		return a.__matmul__ (b);
-	};  
+	};
 	__all__.__matmul__ = __matmul__;
-	
+
 	var __pow__ = function (a, b) {
 		if (typeof a == 'object' && '__pow__' in a) {
 			return a.__pow__ (b);
@@ -1309,9 +1313,9 @@ __pragma__ ('endif')
 		else {
 			return Math.pow (a, b);
 		}
-	};	
+	};
 	__all__.pow = __pow__;
-	
+
 	var __jsmod__ = function (a, b) {
 		if (typeof a == 'object' && '__mod__' in a) {
 			return a.__mod__ (b);
@@ -1323,7 +1327,7 @@ __pragma__ ('endif')
 			return a % b;
 		}
 	}
-	
+
 	var __mod__ = function (a, b) {
 		if (typeof a == 'object' && '__mod__' in a) {
 			return a.__mod__ (b);
@@ -1334,9 +1338,9 @@ __pragma__ ('endif')
 		else {
 			return ((a % b) + b) % b;
 		}
-	};	
+	};
 	__all__.pow = __pow__;
-	
+
 	var __mul__ = function (a, b) {
 		if (typeof a == 'object' && '__mul__' in a) {
 			return a.__mul__ (b);
@@ -1353,9 +1357,9 @@ __pragma__ ('endif')
 		else {
 			return a * b;
 		}
-	};  
+	};
 	__all__.__mul__ = __mul__;
-	
+
 	var __div__ = function (a, b) {
 		if (typeof a == 'object' && '__div__' in a) {
 			return a.__div__ (b);
@@ -1366,9 +1370,9 @@ __pragma__ ('endif')
 		else {
 			return a / b;
 		}
-	};  
+	};
 	__all__.__div__ = __div__;
-	
+
 	var __add__ = function (a, b) {
 		if (typeof a == 'object' && '__add__' in a) {
 			return a.__add__ (b);
@@ -1379,9 +1383,9 @@ __pragma__ ('endif')
 		else {
 			return a + b;
 		}
-	};  
+	};
 	__all__.__add__ = __add__;
-	
+
 	var __sub__ = function (a, b) {
 		if (typeof a == 'object' && '__sub__' in a) {
 			return a.__sub__ (b);
@@ -1392,9 +1396,9 @@ __pragma__ ('endif')
 		else {
 			return a - b;
 		}
-	};  
+	};
 	__all__.__sub__ = __sub__;
-	
+
 	var __eq__ = function (a, b) {
 		if (typeof a == 'object' && '__eq__' in a) {
 			return a.__eq__ (b);
@@ -1404,7 +1408,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.__eq__ = __eq__;
-		
+
 	var __ne__ = function (a, b) {
 		if (typeof a == 'object' && '__ne__' in a) {
 			return a.__ne__ (b);
@@ -1414,7 +1418,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.__ne__ = __ne__;
-		
+
 	var __lt__ = function (a, b) {
 		if (typeof a == 'object' && '__lt__' in a) {
 			return a.__lt__ (b);
@@ -1424,7 +1428,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.__lt__ = __lt__;
-		
+
 	var __le__ = function (a, b) {
 		if (typeof a == 'object' && '__le__' in a) {
 			return a.__le__ (b);
@@ -1434,7 +1438,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.__le__ = __le__;
-		
+
 	var __gt__ = function (a, b) {
 		if (typeof a == 'object' && '__gt__' in a) {
 			return a.__gt__ (b);
@@ -1444,7 +1448,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.__gt__ = __gt__;
-		
+
 	var __ge__ = function (a, b) {
 		if (typeof a == 'object' && '__ge__' in a) {
 			return a.__ge__ (b);
@@ -1454,7 +1458,7 @@ __pragma__ ('endif')
 		}
 	};
 	__all__.__ge__ = __ge__;
-		
+
 	var __getitem__ = function (container, key) {							// Slice c.q. index, direct generated call to runtime switch
 		if (typeof container == 'object' && '__getitem__' in container) {
 			return container.__getitem__ (key);								// Overloaded on container
@@ -1502,7 +1506,6 @@ __pragma__ ('endif')
 		}
 		else {																// Native
 			return args [0] .apply (args [1], args.slice (2));
-		}		
+		}
 	};
 	__all__.__call__ = __call__;
-

--- a/transcrypt/modules/org/transcrypt/__standard__.py
+++ b/transcrypt/modules/org/transcrypt/__standard__.py
@@ -55,7 +55,19 @@ class AssertionError (Exception):
 			Exception.__init__ (self, message, error = error)
 		else:
 			Exception.__init__ (self, error = error)
-	
+
+class NotImplementedError (Exception):
+	def __init__(self, message, error):
+		Exception.__init__(self, message, error = error)
+
+class IndexError(Exception):
+	def __init__(self, message, error):
+		Exception.__init__(self, message, error = error)
+
+class AttributeError(Exception):
+	def __init__(self, message, error):
+		Exception.__init__(self, message, error = error)
+
 __pragma__ ('kwargs')
 
 

--- a/transcrypt/modules/org/transcrypt/autotester/__init__.py
+++ b/transcrypt/modules/org/transcrypt/autotester/__init__.py
@@ -171,6 +171,13 @@ class AutoTester:
 		else:
 			self.refDict[self._currTestlet].append((position,item))
 
+	def expectException(self, func):
+		try:
+			func()
+			return("no exception")
+		except Exception as exc:
+			return("exception")
+
 	def _writeCSS(self, f):
 		cssOut = """
 		<style>

--- a/transcrypt/modules/org/transcrypt/autotester/__init__.py
+++ b/transcrypt/modules/org/transcrypt/autotester/__init__.py
@@ -381,16 +381,19 @@ class AutoTester:
 	def _getRowClsName(self, name):
 		return("mod-" + name)
 
-	def _outputTableResults(self, name, errCount,  testData, refData):
-		collapse = (errCount == 0)
-		self._appendSeqRowName(name, errCount)
-		clsName = self._getRowClsName(name)
-		if ( testData is not None ):
-			for ((testPos, testItem),(refPos,refItem)) in zip(testData, refData):
-				self._appendTableResult(clsName, testPos, testItem, refPos, refItem, collapse)
-		else:
-			for (refPos, refItem) in refData:
-				self._appendTableResult(clsName, None, None, refPos, refItem)
+	def _getTotalErrorCnt(self, testData, refData):
+		""" This method determines the total number of non-matching
+		    values in the test and reference data for a particular module.
+		"""
+		errCount = 0
+		for i,(refPos, refItem) in enumerate(refData):
+			try:
+				testPos,testItem = testData[i]
+				if ( testItem != refItem ):
+					errCount+=1
+			except:
+				errCount+=1
+		return(errCount)
 
 	def _expandCollapseAllFuncs(self):
 		""" This function sets up the callback handlers for the
@@ -434,27 +437,49 @@ class AutoTester:
 		# Setup the functions that expand or contract all
 		# elements of the table
 		self._expandCollapseAllFuncs()
-
 		self._getPythonResults()
+
 		totalErrors = 0
 		sKeys = sorted(self.refDict.keys())
 		for key in sKeys:
 			refData = self.refDict[key]
-			errCount = 0
 			try:
 				testData = self.testDict[key]
-				for ((_,obs),(_,exp)) in zip(testData, refData):
-					if ( obs != exp ):
-						errCount+=1
-			except:
-				# We Don't have Test Data from Javascript to compare
-				# against -
-				testData = None
-				errCount += len(refData)
+				if ( testData is None ):
+					raise KeyError("No Test Data Module: {}".format(key))
+			except KeyError:
+				# No Test Data found for this key - we will populate with
+				# errors for all ref data
+				self._appendSeqRowName(key, len(refData))
+				clsName = self._getRowClsName(key)
+				for i,(refPos, refItem) in enumerate(refData):
+					self._appendTableResult(clsName, None, None, refPos, refItem, False)
+				continue
+			# know we have testData so let's determine the total number of
+			# errors for this test module. This will allow us to both set
+			# the num of errors in the test module header row and set the
+			# rows to the appropriate initial collapsed/expanded state.
+			errCount= self._getTotalErrorCnt(testData, refData)
+			collapse = (errCount == 0)
+			self._appendSeqRowName(key, errCount)
 
-			self._outputTableResults(key, errCount, testData, refData)
-			totalErrors += errCount
+			# Now we will populate the table with all the rows
+			# of data fro the comparison
+			clsName = self._getRowClsName(key)
+			for i,(refPos, refItem) in enumerate(refData):
+				try:
+					# This will throw if testData's length is
+					# shorter than refData's
+					testPos,testItem = testData[i]
+				except:
+					testPos = None
+					testItem = None
 
+				self._appendTableResult(
+					clsName, testPos, testItem, refPos, refItem, collapse
+				)
+
+		totalErrors += errCount
 		self._setOutputStatus( totalErrors == 0 )
 
 	def _showException(self, testname, exc):

--- a/transcrypt/modules/org/transcrypt/autotester/__init__.py
+++ b/transcrypt/modules/org/transcrypt/autotester/__init__.py
@@ -172,6 +172,13 @@ class AutoTester:
 		except Exception as exc:
 			return("exception")
 
+	def checkPad(self, val, count):
+		""" This method is to help manage flow control in unit tests and
+        keep all unit tests aligned
+		"""
+		for i in range(0, count):
+			self.check(val)
+
 	def _writeCSS(self, f):
 		cssOut = """
 		<style>

--- a/transcrypt/modules/org/transcrypt/autotester/__init__.py
+++ b/transcrypt/modules/org/transcrypt/autotester/__init__.py
@@ -474,8 +474,32 @@ class AutoTester:
 		else:
 			stacktrace.innerHTML = "No Stack Trace Available!"
 
-	def run (self, testlet, testletName):
+	def _cleanName(self, name):
+		""" Clean the passed name of characters that won't be allowed
+		    in CSS class or HTML id strings.
+		"""
+		# Convert testletName to replace any of the characters that
+		# are not acceptable in a CSS class or HTML id - this is to
+		# make our lives easier
+		# @note - I'm SPECIFICALLY not using a regex here because the
+		#   regex engine module is still under dev and could possibly
+		#   have issues
+		ret = name
+		invalidChars = [
+			'~', '!', '@', '$', '%',
+			'^', '&', '*', '(', ')',
+			'+', '=', ',', '.', '/',
+			"'", ';', ':', '"', '?',
+			'>', '<', '[', ']', '\\',
+			'{', '}', '|', '`', '#',
+			" ",
+		]
+		for ch in invalidChars:
+			ret = ret.replace(ch, "_")
+		return(ret)
 
+	def run (self, testlet, testletName):
+		testletName = self._cleanName(testletName)
 		self._currTestlet = testletName
 		if __envir__.executor_name == __envir__.transpiler_name:
 			self.testDict[self._currTestlet] = []

--- a/transcrypt/modules/org/transcrypt/autotester/__init__.py
+++ b/transcrypt/modules/org/transcrypt/autotester/__init__.py
@@ -83,26 +83,20 @@ def getFileLocation():
 		else:
 			__pragma__('js', '{}', 'console.log("Failed to Match Frame");')
 			return("UNKNOWN:???")
-	else: #Python
-		# Needed because Transcrypt imports are compile time
-		# @note - I really want to differentiate python from
-		#   javascript environments - I don't care what version
-		#   of python - need to determine what that symbol should
-		#   be
-		__pragma__ ('ifdef', '__py3.6__')
-		from inspect import getframeinfo, stack
-		s = stack()
-		caller = getframeinfo(s[2][0])
-		# Trim the file name path so that we don't get
-		# a lot of unnecessary content
-		filepath = caller.filename
-		# @todo - this is a hack - we should use os.path
-		pathParts = filepath.split('/')
-		filename = "/".join(pathParts[-2:])
-		return( "%s:%d" % (filename, caller.lineno))
-		__pragma__('else')
-		return("UNKNOWN:???")
-		__pragma__ ('endif')
+	#ELSE
+	# Needed because Transcrypt imports are compile time
+	__pragma__("skip")
+	from inspect import getframeinfo, stack
+	s = stack()
+	caller = getframeinfo(s[2][0])
+	# Trim the file name path so that we don't get
+	# a lot of unnecessary content
+	filepath = caller.filename
+	# @todo - this is a hack - we should use os.path
+	pathParts = filepath.split('/')
+	filename = "/".join(pathParts[-2:])
+	return( "%s:%d" % (filename, caller.lineno))
+	__pragma__ ('noskip')
 
 
 

--- a/transcrypt/modules/re/__init__.py
+++ b/transcrypt/modules/re/__init__.py
@@ -1,0 +1,684 @@
+# File: transcript/modules/re/__init__.py
+# Author: Carl Allendorph
+# Date: 13NOV2016
+#
+# Description:
+#    This file contains the definition of a simulated re python
+# regular expression parsing module. The idea is to leverage the
+# javascript native regular expression interface as much as
+# possible. In fact, where necessary, this module chooses the
+# javascript idiosyncracies over the python ones.
+#
+#
+
+from org.transcrypt.stubs.browser import __pragma__
+from re.translate import translate
+from re.re import PyRegExp, _encodeFlags, _decodeFlags
+
+
+# Flags
+
+T = (1<<0)
+TEMPLATE = T
+
+I = (1<<1)
+IGNORECASE = I
+
+# Deprecated
+L = (1<<2)
+LOCALE = L
+
+M = (1<<3)
+MULTILINE = M
+
+S = (1 << 4)
+DOTALL = S
+# Legacy - Unicode by default in Python 3
+U = (1 << 5)
+UNICODE = U
+X = (1 << 6)
+VERBOSE = X
+DEBUG = (1<<7)
+
+A = (1<<8)
+ASCII = A
+
+# This is a javascript specific flag
+Y = (1 << 16)
+STICKY = Y
+G = (1 << 17)
+GLOBAL = G
+# This flag is used to indicate that re module should use
+# the javascript regex engine directly and not attempt to
+# translate the regex string into a python regex
+J = (1<<19)
+JSSTRICT = J
+
+
+
+class error(Exception):
+	""" Regular Expression Exception Class
+	"""
+	def __init__(self, msg, error, pattern = None, flags = 0, pos = None):
+		"""
+		"""
+		Exception.__init__(self, msg, error=error)
+		self.pattern = pattern
+		self.flags = flags
+		self.pos = pos
+		# @todo - lineno and colno attributes
+
+class ReIndexError(IndexError):
+	""" Index Error variant for the re module
+	"""
+	def __init__(self):
+		IndexError.__init__(self, "no such group")
+
+class Match(object):
+	""" Resulting Match from a Regex Operation
+	"""
+	def __init__(self, mObj, string, pos, endpos, rObj):
+		"""
+		"""
+		self._obj = mObj
+
+		self._pos = pos
+		self._endpos = endpos
+		self._re = rObj
+		self._string = string
+
+		# @note - javascript does not have the concept
+		#		of named groups so we will never be able to
+		#		implement this.
+		self._lastgroup = None
+		self._lastindex = self._lastMatchGroup()
+
+	# Read-only Properties
+	def _getPos(self):
+		return(self._pos)
+	def _setPos(self, val):
+		raise AttributeError("readonly attribute")
+	pos = property(_getPos, _setPos)
+
+	def _getEndPos(self):
+		return(self._endpos)
+	def _setEndPos(self, val):
+		raise AttributeError("readonly attribute")
+	endpos = property(_getEndPos, _setEndPos)
+
+	def _getRe(self):
+		return(self._re)
+	def _setRe(self, val):
+		raise AttributeError("readonly attribute")
+	re = property(_getRe, _setRe)
+
+	def _getString(self):
+		return(self._string)
+	def _setString(self, val):
+		raise AttributeError("readonly attribute")
+	string = property(_getString, _setString)
+
+	def _getLastGroup(self):
+		return(self._lastgroup)
+	def _setLastGroup(self, val):
+		raise AttributeError("readonly attribute")
+	lastgroup = property(_getLastGroup, _setLastGroup)
+
+	def _getLastIndex(self):
+		return(self._lastindex)
+	def _setLastIndex(self, val):
+		raise AttributeError("readonly attribute")
+	lastindex = property(_getLastIndex, _setLastIndex)
+
+
+	def _lastMatchGroup(self):
+		""" Determine the last matching group in the object
+		"""
+		if ( len(self._obj) > 1 ):
+			for i in range(len(self._obj)-1,0,-1):
+				if (self._obj[i] is not None):
+					return(i)
+			# None of the capture groups matched -
+			# this seems like it shouldn't happen
+			return(None)
+		else:
+			# No Capture Groups
+			return(None)
+
+	def expand(self, template):
+		"""
+		"""
+		raise NotImplementedError()
+
+	def group(self, *args):
+		""" Return the string[s] for a group[s]
+		if only one group is provided, a string is returned
+		if multiple groups are provided, a tuple of strings is returned
+		"""
+		ret = []
+		if ( len(args) > 0 ):
+			for index in args:
+				if ( index >= len(self._obj) ):
+					# js will return an 'undefined' and we
+					# want this to return an index error
+					# Built-in Exceptions not defined ?
+					raise ReIndexError()
+				ret.append(self._obj[index])
+		else:
+			ret.append(self._obj[0])
+
+		if ( len(ret) == 1 ):
+			return(ret[0])
+		else:
+			return(tuple(ret))
+
+	def groups(self, default = None):
+		""" Get all the groups in this match. Replace any
+		groups that did not contribute to the match with default
+		value.
+		"""
+		if ( len(self._obj) > 1 ):
+			ret = self._obj[1:]
+			return(tuple([x if x is not None else default for x in ret]))
+		else:
+			return(tuple())
+
+	def groupdict(self, default = None):
+		""" The concept of named captures doesn't exist
+		in javascript so this will likely never be implemented.
+		"""
+		raise NotImplementedError()
+
+	def start(self, group = 0):
+		"""
+		"""
+		if ( group >= len(self._obj) ):
+			raise ReIndexError()
+
+		if ( group == 0 ):
+			return(self._obj.index)
+		else:
+			# We don't really have a good way to do
+			# this in javascript. so we will attempt
+			# to match the string we found as a
+			# sub position in the main string - this
+			# isn't perfect though because you could
+			# create a capture that only matches on
+			# the last in a group - this is a difficult
+			# problem to solve without completely
+			# re-writing the regex engine from scratch.
+			if ( self._obj[group] is not None ):
+				r = compile(escape(self._obj[group]), self._re.flags)
+				m = r.search(self._obj[0])
+				if m:
+					return(self._obj.index + m.start())
+				else:
+					raise Exception("Failed to find capture group")
+			else:
+				# This capture did not contribute the match.
+				return(-1)
+
+	def end(self, group = 0):
+		"""
+		"""
+		if ( group >= len(self._obj) ):
+			raise ReIndexError()
+
+		if ( group == 0 ):
+			return( self._obj.index + len(self._obj[0]))
+		else:
+			# We don't really have a good way to do
+			# this in javascript. so we will attempt
+			# to match the string we found as a
+			# sub position in the main string - this
+			# isn't perfect though because you could
+			# create a capture that only matches on
+			# the last in a group - this is a difficult
+			# problem to solve without completely
+			# re-writing the regex engine from scratch.
+			if ( self._obj[group] is not None ):
+				r = compile(escape(self._obj[group]), self._re.flags)
+				m = r.search(self._obj[0])
+				if m:
+					return(self._obj.index + m.end())
+				else:
+					raise Exception("Failed to find capture group")
+			else:
+				# This capture did not contribute the match.
+				return(-1)
+
+	def span(self, group = 0):
+		"""
+		"""
+		if ( group >= len(self._obj) ):
+			raise ReIndexError()
+		return( (self.start(group), self.end(group)) )
+
+class Regex(object):
+	""" Regular Expression Object
+	"""
+	def __init__(self, pattern, flags):
+		"""
+		"""
+		if ( not ((flags & ASCII) > 0) ):
+			flags |= UNICODE
+
+		self._flags = flags
+		self._jsFlags, self._obj = self._compileWrapper(pattern, flags)
+		self._pattern = pattern
+
+
+		# we will determine groups by using another regex
+		# that tacks on an empty match.
+		_, groupCounterRegex = self._compileWrapper(pattern + '|', flags)
+		self._groups = groupCounterRegex.exec('').length-1
+		# Javascript does not have named captures so this
+		# will never have content in js only mode
+		self._groupindex = {}
+
+	# Read-only Properties
+	def _getPattern(self):
+		ret = self._pattern.replace('\\', '\\\\')
+		return(ret)
+	def _setPattern(self, val):
+		raise AttributeError("readonly attribute")
+	pattern = property(_getPattern, _setPattern)
+
+	def _getFlags(self):
+		return(self._flags)
+	def _setFlags(self, val):
+		raise AttributeError("readonly attribute")
+	flags = property(_getFlags, _setFlags)
+
+	def _getGroups(self):
+		return(self._groups)
+	def _setGroups(self, val):
+		raise AttributeError("readonly attribute")
+	groups = property(_getGroups, _setGroups)
+
+	def _getGroupIndex(self):
+		return(self._groupindex)
+	def _setGroupIndex(self, val):
+		raise AttributeError("readonly attribute")
+	groupindex = property(_getGroupIndex, _setGroupIndex)
+
+
+	def _compileWrapper(self, pattern, flags = 0):
+		""" This function wraps the creation of the the
+		regular expresion so that we can catch the
+		Syntax Error exception and turn it into a
+		Python Exception
+		"""
+		jsFlags = self._convertFlags(flags)
+
+		rObj = None
+		errObj = None
+		# The Exceptions need to be converted to python exceptions
+		# in order to propagate appropriately
+		__pragma__('js', '{}',
+							 '''
+							 try {
+							   rObj = new RegExp(pattern, jsFlags)
+							 } catch( err ) {
+							   errObj = err
+							 }
+							 ''')
+
+		if ( errObj is not None ):
+			raise error(errObj.message, errObj, pattern, flags)
+
+		return(jsFlags, rObj)
+
+	def _convertFlags(self, flags):
+		""" Convert the Integer map based flags to a
+		string list of flags for js
+		"""
+		bitmaps = [
+			(DEBUG , ""),
+			(IGNORECASE, "i"),
+			(MULTILINE, "m"),
+			(STICKY, "y"),
+			(GLOBAL, "g"),
+			(UNICODE, "u"),
+		]
+		ret = "".join( [x[1] for x in bitmaps if (x[0] & flags) > 0] )
+		return(ret)
+
+	def _getTargetStr(self, string, pos, endpos):
+		"""
+		"""
+		endPtr = len(string)
+		if ( endpos is not None ):
+			if ( endpos < endPtr):
+				endPtr = endpos
+		if ( endPtr < 0 ):
+			endPtr = 0
+		ret = string[pos:endPtr]
+		return(ret)
+
+	def _patternHasCaptures(self):
+		""" Check if the regex pattern contains a capture
+		necessary to make split behave correctly
+		"""
+		return(self._groups > 0)
+
+	def search(self, string, pos=0, endpos=None):
+		"""
+		"""
+		if ( endpos is None ):
+			endpos = len(string)
+		# @note - pos/endpos don't operate like a slice
+		#		here - we need to search complete string and then
+		#		reject if the match happens outside of pos:endpos
+		rObj = self._obj
+		m = rObj.exec(string)
+		if m:
+			if ( m.index < pos or m.index > endpos ):
+				return(None)
+			else:
+				# Valid match we will create a match object
+				return( Match(m, string, pos, endpos, self))
+		else:
+			return(None)
+
+
+	def match(self, string, pos=0, endpos = None):
+		"""
+		"""
+		target = string
+		if ( endpos is not None ):
+			target = target[:endpos]
+		else:
+			endpos = len(string)
+
+		rObj = self._obj
+		m = rObj.exec(target)
+		if m:
+			# Match only at the beginning
+			if ( m.index == pos ):
+				return( Match(m, string, pos, endpos, self))
+			else:
+				return(None)
+		else:
+			return(None)
+
+	def fullmatch(self, string, pos=0, endpos = None):
+		"""
+		"""
+		target = string
+		strEndPos = len(string)
+		if ( endpos is not None ):
+			target = target[:endpos]
+			strEndPos = endpos
+
+		rObj = self._obj
+		m = rObj.exec(target)
+		if m:
+			obsEndPos = (m.index+len(m[0]))
+			if ( m.index == pos and obsEndPos == strEndPos ):
+				return( Match(m, string, pos, strEndPos, self))
+			else:
+				return(None)
+		else:
+			return(None)
+
+	def split(self, string, maxsplit = 0):
+		"""
+		"""
+		# JS split is slightly different from Python
+		# the "limit" arg limits the number of elements
+		# returned in the list - it doesn't limit the number of
+		# splits.
+
+		if ( maxsplit < 0 ):
+			return([string])
+
+		mObj = None
+		rObj = self._obj
+		if ( maxsplit == 0 ):
+			mObj = string.split(rObj)
+			return(mObj)
+		else:
+			# the split limit parameter in js does not behave like
+			# the maxsplit parameter in python - hence we need to
+			# do this manually.
+			# @todo - make this better handle the flags
+			flags = self._flags
+			flags |= GLOBAL
+
+			_, rObj = self._compileWrapper(self._pattern, flags)
+			ret = []
+			lastM = None
+			cnt = 0
+			for i in range(0, maxsplit):
+				m = rObj.exec(string)
+				if m:
+					cnt += 1
+					if ( lastM is not None ):
+						# subsequent match
+						start = lastM.index + len(lastM[0])
+						head = string[start:m.index]
+						ret.append(head)
+						if ( len(m) > 1 ):
+							ret.extend(m[1:])
+					else:
+						# First match
+						head = string[:m.index]
+						ret.append(head)
+						if ( len(m) > 1 ):
+							ret.extend(m[1:])
+					lastM = m
+				else:
+					break
+
+			if ( lastM is not None ):
+				endPos = lastM.index + len(lastM[0])
+				end = string[endPos:]
+				ret.append(end)
+
+			return(ret)
+
+	def _findAllMatches(self, string, pos = 0, endpos = None):
+		target = self._getTargetStr(string, pos, endpos)
+
+		# Unfortunately, js RegExp.match does not behave
+		# like findall behaves in python - it doesn't
+		# pull out 'captures' like python expects so we
+		# are going to use RegExp.exec instead of match
+		flags = self._flags
+		flags |= GLOBAL
+
+		_, rObj = self._compileWrapper(self._pattern, flags)
+		ret = []
+		while( True ):
+			m = rObj.exec(target)
+			if m:
+				ret.append(m)
+			else:
+				break
+		return(ret)
+
+
+	def findall(self, string, pos = 0, endpos = None):
+		"""
+		"""
+		mlist = self._findAllMatches(string, pos, endpos)
+
+		def mSelect(m):
+			if ( len(m) > 2 ):
+				# Captures Present and we need to
+				# convert to a tuple
+				return(tuple(m[1:]))
+			elif ( len(m) == 2 ):
+				# 1 Capture
+				return(m[1])
+			else:
+				# No captures
+				return(m[0])
+
+		ret = map(mSelect, mlist)
+
+		return(ret)
+
+	def finditer(self, string, pos, endpos = None):
+		"""
+		"""
+		mlist = self._findAllMatches(string, pos, endpos)
+		ret = map(lambda m: Match(m, string, 0, len(string), self), mlist)
+		return( iter(ret) )
+
+	def sub(self, repl, string, count = 0):
+		"""
+		"""
+		ret,_ = self.subn(repl, string, count)
+		return(ret)
+
+
+	def subn(self, repl, string, count = 0):
+		"""
+		"""
+		# For this we are going to use the 'exec' method
+		# because the 'replace' method in javascript is broken
+		# for what we are trying do. There is no way to get
+		# the function callback concept to work.
+		flags = self._flags
+		flags |= GLOBAL
+
+		_, rObj = self._compileWrapper(self._pattern, flags)
+		ret = ""
+		totalMatch = 0
+		lastEnd = -1
+		while(True):
+			if (count > 0):
+				if ( totalMatch >= count ):
+					if ( lastEnd < 0 ):
+						# This is an odd case - if we got
+						# here it means there is a bug in our code.
+						return(ret,totalMatch)
+					else:
+						ret += string[lastEnd:m.index]
+						return(ret,totalMatch)
+
+			m = rObj.exec(string)
+			if m:
+				if ( lastEnd < 0 ):
+					# first match
+					ret += string[:m.index]
+				else:
+					# subsequent match
+					ret += string[lastEnd:m.index]
+
+				try:
+					content = repl(Match(m, string, 0, len(string), self))
+					ret += content
+				except:
+					# repl is likely not callable so - we will
+					# instead try to use it as a string
+					ret += repl
+
+				totalMatch+=1
+				# Update the last end so we know where to start
+				# copying from on the next pass
+				lastEnd = m.index + len(m[0])
+			else:
+				# Failed to match means that there are no more
+				# matches in the string
+				if ( lastEnd < 0 ):
+					# No matches were found - we return string
+					# unmolested
+					return(string, 0)
+				else:
+					ret += string[lastEnd:]
+					return(ret,totalMatch)
+
+def compile(pattern, flags = 0):
+	""" Compile a regex object and return
+	an object that can be used for further processing.
+	"""
+	if ( flags & JSSTRICT ):
+		p = Regex(pattern, flags)
+	else:
+		passedFlags = _decodeFlags(flags)
+		jsTokens, jsflags, namedGroups, nCaptureGroups = translate(pattern)
+		flags |= _encodeFlags(jsflags)
+		p = PyRegExp(pattern, jsTokens, jsflags + passedFlags, flags, namedGroups, nCaptureGroups)
+	return(p)
+
+def search(pattern, string, flags = 0):
+	""" Search a string for a particular matching pattern
+	"""
+	p = Regex(pattern, flags)
+	return( p.search(string) )
+
+def match(pattern, string, flags = 0):
+	""" Match a string for a particular pattern
+	"""
+	p = Regex(pattern, flags)
+	return( p.match(string) )
+
+def fullmatch(pattern, string, flags = 0):
+	"""
+	"""
+	p = Regex(pattern, flags)
+	return( p.fullmatch(string) )
+
+def split(pattern, string, maxsplit = 0, flags = 0):
+	"""
+	"""
+	p = Regex(pattern, flags)
+	return( p.split(string, maxsplit) )
+
+def findall(pattern, string, flags = 0):
+	"""
+	"""
+	p = Regex(pattern, flags)
+	return( p.findall(string) )
+
+def finditer(pattern, string, flags = 0):
+	"""
+	"""
+	p = Regex(pattern, flags)
+	return( p.finditer(string) )
+
+def sub(pattern, repl, string, count = 0, flags = 0):
+	"""
+	"""
+	p = Regex(pattern, flags)
+	return( p.sub(repl, string, count) )
+
+def subn(pattern, repl, string, count = 0, flags = 0):
+	"""
+	"""
+	p = Regex(pattern, flags)
+	return( p.subn(repl, string, count) )
+
+def escape(string):
+	""" Escape a passed string so that we can send it to the
+	regular expressions engine.
+	"""
+	ret = None
+	def replfunc(m):
+		if ( m[0] == "\\" ):
+			return("\\\\\\\\")
+		else:
+			return("\\\\" + m[0])
+
+	# @note - I had an issue getting replfunc to be called in
+	#		 javascript correctly when I didn't use this pragma
+	#		 not sure if I was just doing it wrong or what
+	__pragma__(
+		'js', '{}',
+		'''
+		var r = /[^A-Za-z\d]/g;
+		ret = string.replace(r, replfunc);
+		''')
+	if ( ret is not None ):
+		return(ret)
+	else:
+		raise Exception("Failed to escape the passed string")
+
+def purge():
+	""" I think this function is unnecessary but included to keep interface
+	consistent.
+	"""
+	pass

--- a/transcrypt/modules/re/re.py
+++ b/transcrypt/modules/re/re.py
@@ -1,0 +1,264 @@
+# Copyright
+
+# MIT License
+# Copyright (c) 2016
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from re.translate import translate
+
+JAVASCRIPT     = 0b1000000000
+
+ASCII      = A = 0b100000000
+DEBUG          = 0b010000000
+VERBOSE    = X = 0b001000000
+UNICODE    = U = 0b000100000
+DOTALL     = S = 0b000010000
+MULTILINE  = M = 0b000001000
+LOCALE     = L = 0b000000100
+IGNORECASE = I = 0b000000010
+T = 0b000000001
+
+_bitFlagFormatBits = [A, X, U, S, M, L, I]
+_bitFlagFormatStr  = ['a', 'x', 'u', 's', 'm', 'L', 'i']
+# TODO: js-specific flags should also be supported,
+#       but they should be supported everywhere (e.g `compile("(?y)whatever")` should be valid).
+_jsFlags = ['i', 'g', 'm']
+
+
+def _decodeFlags(bitFlags):
+    flags = ''
+    for x in range(0, len(_bitFlagFormatBits)):
+        if bitFlags & _bitFlagFormatBits[x]:
+            flags += _bitFlagFormatStr[x]
+    return flags
+
+
+def _encodeFlags(flags):
+    bitFlags = 0
+    for flag in flags:
+        x = _bitFlagFormatStr.indexOf(flag)
+        if (x > -1):
+            bitFlags |= _bitFlagFormatBits[x]
+    return bitFlags
+
+
+def _getJsFlags(flags):
+    jsFlags = ''
+    for flag in flags:
+        if flag in _jsFlags:
+            jsFlags += flag
+    return jsFlags
+
+
+class Match:
+    def __init__(self, rgx, groups, txt, start, end):
+        self._startIndex = groups.index
+        self._groupsList = [g if g is not js_undefined else None for g in groups]
+        self._namedGroups = rgx.groupindex
+
+        self.pos = start
+        self.endpos = end
+        self.re = rgx
+        self.string = txt
+        self.lastindex = len(groups) - 1
+        self.lastgroup = None
+
+        for groupName, groupId in self._namedGroups.items():
+            if groupId == self.lastindex:
+                self.lastgroup = groupName
+                break
+
+        for idx, group in enumerate(groups):
+            self[idx] = group
+
+    def group(self, *groupIds):
+        if len(groupIds) == 0:
+            return self._groupsList[0]
+
+        result = []
+        for id in groupIds:
+            if type(id) is str:
+                result.append(self._groupsList[self._namedGroups[id]])
+            else:
+                result.append(self._groupsList[id])
+
+        if len(result) == 1:
+            return result[0]
+        return tuple(result)
+
+    def groups(self, default=None):
+        return tuple([g if g is not None else default for g in self._groupsList[1:]])
+
+    def groupdict(self, default=None):
+        d = dict()
+        for gName in Object.js_keys(self._namedGroups):
+            gId = self._namedGroups[gName]
+            value = self._groupsList[gId]
+            d[gName] = default if value is None else value
+        return d
+
+    def end(self, group=None):
+        if group is not None:
+            raise Error("match.end() with argument is not supported")
+        return self._startIndex + self._groupsList[0].length
+
+    def start(self, group=None):
+        if group is not None:
+            raise Error("match.start() with argument is not supported")
+        return self._startIndex
+
+    def span(self, group=None):
+        if group is not none:
+            raise Error("match.span() with argument is not supported")
+        return (self.start(), self.end())
+
+
+class PyRegExp:
+    def __init__(self, pyPattern, jsTokens, flags, bitFlags, namedGroups, nCaptureGroups):
+        self._flags = flags
+        self._jsFlags = _getJsFlags(self._flags)
+        self._jsPattern = RegExp(''.join(jsTokens), self._jsFlags)
+        self._jsTokens = jsTokens
+
+        self.flags = bitFlags
+        self.groups = nCaptureGroups
+        self.groupindex = namedGroups
+        self.pattern = pyPattern
+
+    def _getFirstMatch(self, txt, start, end):
+        pattern = self._jsPattern
+
+        #  In python, `^` with `start` will always fail to match _unless_ `txt[start - 1]` is `\n` and multi-line is active.
+        #  Interestingly, `$` with `end` works as expected and requires no special handling.
+        if start != 0 and 'm' not in self._flags or txt[start - 1] != '\n' and self._jsTokens:
+            strRgx = ''
+            for token in self._jsTokens:
+                if token == '^':
+                    # impossible group - will always fail.
+                    # we can't just return None, since the '^' might be inside something like `(foo|^)`.
+                    token = '[^\S\s]'
+                strRgx += token
+            pattern = RegExp(strRgx, self._jsFlags)
+
+        return txt[start:end].match(pattern)
+
+    def search(self, txt, start=0, end=None):
+        if end is None:
+            end = len(txt)
+
+        match = self._getFirstMatch(txt, start, end)
+        if match is not None:
+            return Match(self, match, txt, start, end)
+        return match
+
+    def match(self, txt, start=0, end=None):
+        if end is None:
+            end = len(txt)
+
+        match = self._getFirstMatch(txt, start, end)
+        if match is None or match.index > start:
+            return None
+        return Match(self, match, txt, start, end)
+
+    def fullmatch(self, txt, start=0, end=None):
+        if end is None:
+            end = len(txt)
+
+        match = self._getFirstMatch(txt, start, end)
+        if match.index != 0 | match.index + len(match[0]) != end:
+            return None
+        return Match(self, match, txt, start, end)
+
+    def split(self, txt, maxsplit=None):
+        if maxsplit is None:
+            splitted = txt.split(self._jsPattern)
+        else:
+            splitted = txt['split'](self._jsPattern, maxsplit)
+
+            consumed = 0
+            for split in splitted:
+                consumed += len(split)
+            # if we split "test%test%test" with maxsplit 1,
+            # python will give ["test", "test%test"], and js ["test", "%test%test"]
+            # this last bit fixes that
+            last_el = txt[consumed + 1:]
+            skip = len(last_el.match(self._jsPattern)[0])
+            splitted.append(last_el[skip:])
+
+        return splitted
+
+    def findall(self, txt, start=0, end=None):
+        if end is None:
+            end = len(txt)
+        # modify pattern to match globally
+        globalPattern = RegExp(self._jsPattern, 'g')
+        # not correct? probably needs the same logic as `_getFirstMatch()`, but will work for now
+        txt = txt[start:end]
+        result = []
+
+        while True:
+            match = globalPattern.exec(txt)
+            if match:
+                if (len(match) > 2):
+                    result.append(tuple(match[1:]))
+                elif (len(match) == 2):
+                    result.append(match[1])
+                else:
+                    result.append(match[0])
+            else:
+                break
+
+        return result
+
+
+def compile(pyPattern, bitFlags=0):
+    passedFlags = _decodeFlags(bitFlags)
+
+    if not flags & JAVASCRIPT:
+        jsTokens, flags, namedGroups, nCaptureGroups = translate(pyPattern)
+        bitFlags |= _encodeFlags(flags)
+        return PyRegExp(pyPattern, jsTokens, flags + passedFlags, bitFlags, namedGroups, nCaptureGroups)
+    return PyRegExp(pyPattern, None, '', dict())
+
+
+def search(pyPattern, txt, bitFlags=0):
+    rgx = compile(pyPattern, bitFlags)
+    return rgx.search(txt)
+
+
+def match(pyPattern, txt, bitFlags=0):
+    rgx = compile(pyPattern, bitFlags)
+    return rgx.match(txt)
+
+
+def split(pyPattern, txt, maxsplit, bitFlags=0):
+    rgx = compile(pyPattern, bitFlags)
+    return rgx.split(txt, maxsplit=None)
+
+
+def findall(pyPattern, txt, bitFlags=0):
+    rgx = compile(pyPattern, bitFlags)
+    return rgx.findall(txt)
+
+
+def fullmatch(pyPattern, txt, bitFlags=0):
+    rgx = compile(pyPattern, bitFlags)
+    return rgx.fullmatch(txt)

--- a/transcrypt/modules/re/translate.py
+++ b/transcrypt/modules/re/translate.py
@@ -1,0 +1,343 @@
+# MIT License
+# Copyright (c) 2016
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+VERBOSE = False
+
+
+# Represents a regex group (e.g /()/, /(?:)/ /(?=), etc).
+# `start` and `end` is the index of the groups start and end token in the token list.
+class Group:
+    def __init__(self, start, end, klass):
+        self.start = start
+        self.end = end
+        self.klass = klass
+
+    def __repr__(self):
+        return str((self.start, self.end, self.klass))
+
+
+# Generates a list of `Group`s from a token list.
+def generateGroupSpans(tokens):
+    groupInfo = []
+
+    idx = 0
+    for token in tokens:
+        if token.name.startswith('('):
+            groupInfo.append(Group(idx, None, token.name))
+        elif token.name == ')':
+            for group in reversed(groupInfo):
+                if group.end is None:
+                    group.end = idx
+        idx += 1
+    return groupInfo
+
+
+def countCaptureGroups(tokens):
+    groupInfo = generateGroupSpans(tokens)
+    count = 0
+
+    for token in tokens:
+        if token.name == '(':
+            count += 1
+
+    return count
+
+
+# Get the `Group` for a capture group with a given id or name.
+def getCaptureGroup(groupInfo, namedGroups, groupRef):
+    try:
+        id = int(groupRef)
+    except:
+        id = namedGroups[groupRef]
+    search = 0
+    for group in groupInfo:
+        if group.klass == '(':
+            search += 1
+            if search == id:
+                return group
+
+
+# Regex conditionals is implemented by splitting the regex into two parts,
+# one for the if case and one for the else case.
+# Example: if the input is (a)?(b)?(?(1)a|c)(?(2)b|d),
+# the first conditional will cause it to split into these parts:
+# `()(b)?c(?(2)b|d)` and `(a)(b)?a(?(2)b|d)`
+# The second conditional will then cause each part to split into two, creating four parts in total:
+# `()()cd`, `()(b)cb`, `(a)()ad` and `(a)(b)ab`
+# The parts are then merged into a single regex: `part1|part2|part3|part4`.
+# TODO: This causes the group indexes to be messed up. To fix it, group indexes must be modified with `% len(groups) + 1`.
+def splitIfElse(tokens, namedGroups):
+    variants = []
+    groupInfo = generateGroupSpans(tokens)
+
+    for group in groupInfo:
+        if group.klass == '(?<':
+            iff = tokens[:]
+            els = tokens[:]
+            conStart = group.start
+            conEnd   = group.end
+
+            ref = tokens[conStart + 1].name
+            captureGroup = getCaptureGroup(groupInfo, namedGroups, ref)
+            captureGroupModifier = tokens[captureGroup.end + 1]
+
+            if captureGroupModifier.name in ['?', '*'] or captureGroupModifier.name.startswith('{0,'):
+                if captureGroupModifier.name == '?':
+                    iff[captureGroup.end + 1] = None
+                elif captureGroupModifier.name == '*':
+                    iff[captureGroup.end + 1] = Token('+')
+                elif captureGroupModifier.name.startswith('{0,'):
+                    iff[captureGroup.end + 1].name[0:3] = '{1,'
+                els[captureGroup.end + 1] = None
+
+                hasElse = False
+                for idx in range(conStart, conEnd):
+                    if tokens[idx].name == '|':
+                        hasElse = True
+                        els.pop(conEnd)
+                        iff[idx:conEnd + 1] = []
+                        els[conStart:idx + 1] = []
+                        break
+
+                if not hasElse:
+                    els[conStart:conEnd + 1] = []
+                    iff.pop(conEnd)
+
+                iff[conStart:conStart + 3] = []
+                els[captureGroup.start:captureGroup.end + 1] = [Token('('), Token(')')]
+                iff.remove(None)
+                els.remove(None)
+                variants.append(iff)
+                variants.append(els)
+
+            else:  # the easy case - 'else' is impossible
+                pastIff = False
+                for idx in range(conStart, conEnd):
+                    if iff[idx].name == '|':
+                        iff = tokens[:idx]
+                        iff.extend(tokens[conEnd + 1:])
+                        break
+                iff[conStart:conStart + 3] = []
+                variants.append(iff)
+            break
+
+    if not variants:
+        return [tokens]
+
+    allVariants = []
+    for variant in variants:
+        allVariants.extend(splitIfElse(variant, namedGroups))
+    return allVariants
+
+
+class Token:
+    def __init__(self, name, paras=None, pure=False):
+        if paras is None:
+            paras = []
+        self.name  = name
+        self.paras = paras
+        self.pure = pure
+        # tmp until I have thought of something better
+        self.isModeGroup = False
+
+    def __repr__(self):
+        return self.name
+
+    def resolve(self):
+        paras = ''
+        for para in self.paras:
+            paras += str(para)
+
+        return self.name + paras
+
+
+def shift(stack, queue):
+    done = not bool(queue)
+    if not done:
+        stack.append(Token(queue[0], [], True))
+        queue = queue[1:]
+    return stack, queue, done
+
+
+# Shift-reduce parser. Creates the next state of the stack & queue.
+def shiftReduce(stack, queue, namedGroups, flags):
+    pyFlags = 'iLmsux'
+    done = False
+    high = len(stack) - 1
+
+    if len(stack) < 2:
+        stack, queue, done = shift(stack, queue)
+        return stack, queue, flags, done
+
+    s0 = stack[high]     if len(stack) > 0 else Token('')
+    s1 = stack[high - 1] if len(stack) > 1 else Token('')
+
+    if VERBOSE:
+        for token in stack:
+            console.log(token.resolve(), '\t', end='')
+        console.log('')
+
+    if s1.name == '\\':
+        if s0.name == 'A':
+            stack[-2:] = [Token('^')]
+
+        elif s0.name == 'a':
+            stack[-2:] = [Token('\\07')]
+
+        elif s0.name == 'Z':
+            stack[-2:] = [Token('$')]
+
+        else:
+            stack[-2:] = [Token('\\' + s0.name)]
+
+    elif s0.name == '$' and s0.pure:
+        stack.pop()
+        stack.extend([Token('(?='), Token('\\n'), Token('?'), Token('$'), Token(')')])
+
+    elif s1.name == '{':
+        if s0.name == ',' and len(s1.paras) == 0:
+            s1.paras.append('0')
+            s1.paras.append(',')
+        else:
+            if s0.name == '}':
+                s1.paras.append('}')
+                s1.name = s1.resolve()
+                s1.paras = []
+            else:
+                s1.paras.append(s0.name)
+
+        stack = stack[:-1]
+
+    elif s1.name == '[' and s0.name == '^':
+        stack[-2:] = [Token('[^')]
+
+    elif s1.name == '(' and s0.name == '?':
+        stack[-2:] = [Token('(?')]
+
+    elif s1.name in ['*', '+', '?'] and s0.name == '?':
+        stack[-2:] = [Token(s1.name + '?')]
+
+    elif s1.isModeGroup and s0.name == ')':
+        stack = stack[:-2]
+
+    elif s1.name == '(?':
+        if s0.name in pyFlags:
+            if s0.name == 'i':
+                flags += 'i'
+            elif s0.name == 'm':
+                flags += 'm'
+            elif s0.name == 's':
+                flags += 's'
+            else:
+                raise Error('Unsupported flag: ' + s0.name)
+
+            stack.pop()
+            s1.isModeGroup = True
+
+        else:
+            if s0.name == '(':
+                s0.name = '<'
+
+            newToken = Token('(?' + s0.name)
+            stack[-2:] = [newToken]
+
+    elif s1.name == '(?<':
+        if s0.name == ')':
+            stack[-1:] = [Token(''.join(s1.paras)), Token('>')]
+            s1.paras = []
+        else:
+            s1.paras.append(s0.name)
+            stack.pop()
+
+    elif s1.name == '(?P':
+        stack[-2:] = [Token('(?P' + s0.name)]
+
+    elif s1.name == '(?P<':
+        if s0.name == '>':
+            # todo: don't count every time, just keep track of it over time
+            namedGroups[''.join(s1.paras)] = countCaptureGroups(stack) + len(namedGroups) + 1
+            stack[-2:] = [Token('(')]
+        else:
+            s1.paras.append(s0.name)
+            stack.pop()
+
+    elif s1.name == '(?P=':
+        if s0.name == ')':
+            stack[-2:] = [Token('\\' + namedGroups[s1.paras[0]])]
+        elif not s1.paras:
+            s1.paras.append(s0.name)
+            stack.pop()
+        else:
+            s1.paras[0] += s0.name
+            stack.pop()
+
+    elif s1.name == '(?#':
+        if s0.name == ')':
+            stack = stack[:-2]
+        else:
+            stack = stack[:-1]
+
+    else:
+        stack, queue, done = shift(stack, queue)
+
+    return stack, queue, flags, done
+
+
+# Takes a re-regex and returns a js-regex.
+# TODO: Returns way to many values.
+def translate(rgx):
+    stack = []
+    queue = list(rgx)
+
+    flags = ''
+    namedGroups = dict()
+
+    nloop = 0
+
+    while True:
+        nloop += 1
+        if nloop > 50:
+            console.log("Failed to parse...", rgx)
+            break
+
+        stack, queue, flags, done = shiftReduce(stack, queue, namedGroups, flags)
+        if done:
+            break
+
+    variants = splitIfElse(stack, namedGroups)
+    n_splits = len(variants)
+
+    final = []
+    for i in range(0, len(variants)):
+        final.extend(variants[i])
+        if i < len(variants) - 1:
+            final.append(Token('|'))
+    stack = final
+
+    groupInfo = generateGroupSpans(stack)
+    resolvedTokens = []
+
+    for token in stack:
+        stringed = token.resolve()
+        if 's' in flags and stringed == '.':
+            stringed = '[\s\S]'
+        resolvedTokens.append(stringed)
+    return resolvedTokens, flags, namedGroups, countCaptureGroups(stack), n_splits


### PR DESCRIPTION
Hi, 

The primary thrust of this PR is to address issue #98 - the python re module. This PR also contains a few commits that update the autotester code base. The most important of these is a bug fix that corrects an error in the autotester where false positives were possible if a test suite contained only a single module and had an exception. Additionally, there is a single commit that fixes the KeyError exception (it was in \_\_standard\__.py but not in \_\_builtin__.js) and adds new exceptions from the standard builtin exceptions list to support the re module.

For the Python regular expressions module, I've taken the approach discussed in the Issue #98. The re module has two modes that can be controlled via a flag. The first mode translates python re syntax into javascript syntax and attempts to mimic python as much as possible leveraging @GULPF 's translation engine. This is the default mode. The second mode uses a strict javascript syntax mode to implement the python re API. This second mode has some limitations (named captures, etc don't exist in javascript), but it is functional for most simple regular expressions. 

I've added a base set of unit tests for both modes. These unit tests don't cover everything but they cover a fair amount of the API's basic structure. Note that not all tests pass at this point, due to bugs in the re module as well as bugs in transcrypt core. I have not included the re unit tests in the travis CI yet.

@GULPF - in this PR, I've basically just copied and pasted the code from your repo into the re module including license and referenced it directly as a first pass. This is obviously not optimal as there a lot of duplicate portions of the API in your implementation and in mine, but this at least gives us a starting point that we can build on. Additionally, the license for this code is MIT which I believe is more liberal than the Apache license so it is ok to distribute in this manner but we should likely discuss.
