### PR TITLE
modules: Initial implementation of the `logging` python module

### DIFF
--- a/transcrypt/development/automated_tests/logging/autotest.py
+++ b/transcrypt/development/automated_tests/logging/autotest.py
@@ -1,0 +1,12 @@
+# Main unit test platform for the logging module
+
+from org.transcrypt.stubs.browser import __pragma__
+import org.transcrypt.autotester
+
+import logger_tests
+
+autoTester = org.transcrypt.autotester.AutoTester ()
+
+autoTester.run( logger_tests, "logger_tests" )
+
+autoTester.done()

--- a/transcrypt/development/automated_tests/logging/logger_tests.py
+++ b/transcrypt/development/automated_tests/logging/logger_tests.py
@@ -1,0 +1,270 @@
+
+from org.transcrypt.stubs.browser import __pragma__, __envir__
+
+#from logging import *
+import logging
+#import logging as log
+
+class TestHandler(logging.Handler):
+    """ This handler is intended to make it easier to test the
+    logging module output without requiring the console or the
+    sys.stderr.
+    """
+    def __init__(self, test, level):
+        """
+        """
+        logging.Handler.__init__(self, level)
+        self._test = test
+
+    def emit(self, record):
+        """
+        """
+        msg = self.format(record)
+        self._test.check(msg)
+
+
+def logger_basics(test):
+    # @note - basicConfig has some issues because the
+    #   kwargs parameter is difficult work
+    # basehdlr = TestHandler(test, 0)
+    # fmt = logging.Formatter(style="{")
+    # basehdlr.setFormatter(fmt)
+
+    # logging.basicConfig(handlers = [basehdlr])
+
+    logger = logging.getLogger("tester")
+    test.check(logger.name)
+    test.check(logger.level)
+    test.check(logger.hasHandlers())
+
+    # level set methods
+    test.check(logger.getEffectiveLevel())
+    logger.setLevel(10)
+    test.check(logger.level)
+    testLevel = "USERDEFLEVEL"
+    test.check(test.expectException(lambda : logger.setLevel(testLevel)))
+    test.check(logging.getLevelName(testLevel))
+    for i in range(0,50,5):
+        test.check(logging.getLevelName(i))
+
+    logging.addLevelName(35, testLevel)
+    test.check(logging.getLevelName(testLevel))
+    for i in range(0,50,5):
+        test.check(logging.getLevelName(i))
+
+    for i in range(0,50,5):
+        test.check(logger.isEnabledFor(i))
+
+
+    hdlr = TestHandler(test, 30)
+    fmt = logging.Formatter(style="{")
+    hdlr.setFormatter(fmt)
+    logger.addHandler(hdlr)
+
+    test.check(logger.hasHandlers())
+
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("The house is on fire")
+
+    logger.setLevel(0)
+
+    # @note - Transcrypt only has the '.format()' method for
+    #    string formatting but python's logging module has a
+    #    fixed mode using the old-style % formating concept
+    #    this is obviously non-optimal from a testing perspective
+    #    as well as form a interop perspective...
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logger.debug("This is a debug msg {}", 1)
+    else:
+        logger.debug("This is a debug msg %d", 1)
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logger.info("This is an info message: {}", "blarg")
+    else:
+        logger.info("This is an info message: %s", "blarg")
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logger.warning("This is a {} warning message in the {}", "blue", "barn")
+    else:
+        logger.warning("This is a %s warning message in the %s", "blue", "barn")
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logger.error("This is an error message: {} {} {}", 3, "23", 4)
+    else:
+        logger.error("This is an error message: %d %s %d", 3, "23", 4)
+
+    logger.critical("The house is on fire")
+
+    # Test the handler level change
+    hdlr.setLevel(30)
+    logger.debug("This is a debug msg {}", 1)
+    logger.info("This is an info message: {}", "blarg")
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logger.warning("This is a {} warning message in the {}", "blue", "barn")
+    else:
+        logger.warning("This is a %s warning message in the %s", "blue", "barn")
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logger.error("This is an error message: {} {} {}", 3, "23", 4)
+    else:
+        logger.error("This is an error message: %d %s %d", 3, "23", 4)
+
+    logger.critical("The house is on fire")
+
+
+def logging_api_tests(test):
+
+    logger = logging.getLogger()
+    logger.setLevel(20)
+    hdlr = TestHandler(test, 30)
+    fmt = logging.Formatter(style="{")
+    hdlr.setFormatter(fmt)
+    logger.addHandler(hdlr)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+    logger.setLevel(40)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+    hdlr.setLevel(20)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+    hdlr.setLevel(39)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+    hdlr.setLevel(41)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+    hdlr.setLevel(40)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+    logger.setLevel(39)
+
+    logging.critical("Another Crazy Message!")
+    logging.error("Oh the humanity")
+    logging.warning("Is it hot in here?")
+    logging.info("Big Bird says Hello!")
+    logging.debug("No body gonna see this message")
+
+
+def formatter_tests(test):
+    """ This function contains some tests of the formatter objects
+    """
+    logger = logging.getLogger("fmttest")
+    logger.setLevel(10)
+
+    hdlr = TestHandler(test, 30)
+    fmt = logging.Formatter(style="{", fmt="{levelname}:{name}:{message}")
+    test.check(fmt.usesTime())
+    hdlr.setFormatter(fmt)
+    logger.addHandler(hdlr)
+
+    hdlr.setLevel(30)
+    test.check(hdlr.name)
+    hdlr.name = "Asdf"
+    test.check(hdlr.name)
+    test.check(hdlr.level)
+
+    test.check(logger.hasHandlers())
+
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("The house is on fire")
+
+    hdlr.setLevel(0)
+
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("The house is on fire")
+
+
+def console_test(test):
+    """ @note- this test will only generate minimal
+    autotester results but can be manually inspected in the
+    console.log
+    """
+    logger = logging.getLogger("consoleTest")
+
+    logger.setLevel(10)
+
+    hdlr = TestHandler(test, 30)
+    fmt = logging.Formatter(style="{", fmt="{name}:{message}")
+    test.check(fmt.usesTime())
+    hdlr.setFormatter(fmt)
+    hdlr.setLevel(20)
+    logger.addHandler(hdlr)
+
+    shdlr = logging.StreamHandler()
+    shdlr.setFormatter(fmt)
+    shdlr.setLevel(20)
+    logger.addHandler(shdlr)
+
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("The house is on fire")
+
+    shdlr.setLevel(10)
+
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("The house is on fire")
+
+    shdlr.setLevel(40)
+
+    logger.debug("This is a debug message")
+    logger.info("This is an info message")
+    logger.warning("This is a warning message")
+    logger.error("This is an error message")
+    logger.critical("The house is on fire")
+
+
+def run(test):
+    """ These are general logging test for the Logger class and
+    associated classes. This does not cover the configuration module.
+    """
+
+    logger_basics(test)
+    logging_api_tests(test)
+    formatter_tests(test)
+    console_test(test)

--- a/transcrypt/modules/logging/__init__.py
+++ b/transcrypt/modules/logging/__init__.py
@@ -1,0 +1,2093 @@
+# Copyright 2001-2016 by Vinay Sajip. All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright notice appear in all copies and that
+# both that copyright notice and this permission notice appear in
+# supporting documentation, and that the name of Vinay Sajip
+# not be used in advertising or publicity pertaining to distribution
+# of the software without specific, written prior permission.
+# VINAY SAJIP DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL
+# VINAY SAJIP BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
+# ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+# IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+# Updated for Transcrypt by Carl Allendorph 2016
+
+"""
+Logging package for Python. Based on PEP 282 and comments thereto in
+comp.lang.python.
+
+Copyright (C) 2001-2016 Vinay Sajip. All Rights Reserved.
+
+To use, simply 'import logging' and log away!
+
+Edited By Carl Allendorph 2016 for the Transcrypt Project
+
+This code base was originally pulled from the Python project to
+maintain as much compatibility in the interfaces as possible.
+
+Limitations:
+- The output formatting is currently limited to string.format() style
+    formatting because of Transcrypt. This means that PercentStyle
+    formatting and string template formatting is disabled and not
+    available.
+- I've had to makes some hacks to work around shortcomings in Transcrypt
+    at this point but most of these are superficial.
+- The components of the logging dealing with exceptions, stack traces,
+    and other content are not implemented at this point
+- Anything related to threads and processes is set to default values
+    of None.
+- StreamHandler publishes content to console.log as sys.stderr is not
+    available.
+- Integration with the `warnings` python module is not implemented because
+    `warnings` does not exist yet.
+
+Automated tests are available in the logging test module.
+
+"""
+from org.transcrypt.stubs.browser import __pragma__
+import time
+#import sys, os, time, io, traceback, warnings, weakref, collections
+
+#from string import Template
+
+# __all__ = [
+#     'BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
+#     'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
+#     'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
+#     'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
+#     'captureWarnings', 'critical', 'debug', 'disable', 'error',
+#     'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
+#     'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
+#     'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
+#     'lastResort', 'raiseExceptions']
+
+__author__  = "Vinay Sajip <vinay_sajip@red-dove.com>, Carl Allendorph"
+__status__  = "experimental"
+# The following module attributes are no longer updated.
+__version__ = "0.5.1.2"
+__date__    = "15 November 2016"
+
+#---------------------------------------------------------------------------
+#       Miscellaneous module data
+#---------------------------------------------------------------------------
+
+#
+#_startTime is used as the base when calculating the relative time of events
+#
+_startTime = time.time()
+
+#
+#raiseExceptions is used to see if exceptions during handling should be
+#propagated
+#
+raiseExceptions = True
+
+#
+# If you don't want threading information in the log, set this to zero
+#
+# @note - This currently doesn't do anything in transcrypt because there
+#       is no logging facility. I've left it here for compatiblity
+logThreads = True
+
+#
+# If you don't want multiprocessing information in the log, set this to zero
+#
+# @note - This currently doesn't do anything in transcrypt because there
+#       is no multiprocessing facility. I've left it here for compatiblity
+logMultiprocessing = True
+
+#
+# If you don't want process information in the log, set this to zero
+#
+# @note - This currently doesn't do anything in transcrypt because there
+#       is no separate process facility. I've left it here for compatiblity
+logProcesses = True
+
+#---------------------------------------------------------------------------
+#       Level related stuff
+#---------------------------------------------------------------------------
+#
+# Default levels and level names, these can be replaced with any positive set
+# of values having corresponding names. There is a pseudo-level, NOTSET, which
+# is only really there as a lower limit for user-defined levels. Handlers and
+# loggers are initialized with NOTSET so that they will log all messages, even
+# at user-defined levels.
+#
+
+CRITICAL = 50
+FATAL = CRITICAL
+ERROR = 40
+WARNING = 30
+WARN = WARNING
+INFO = 20
+DEBUG = 10
+NOTSET = 0
+
+_levelToName = {
+    CRITICAL: 'CRITICAL',
+    ERROR: 'ERROR',
+    WARNING: 'WARNING',
+    INFO: 'INFO',
+    DEBUG: 'DEBUG',
+    NOTSET: 'NOTSET',
+}
+_nameToLevel = {
+    'CRITICAL': CRITICAL,
+    'FATAL': FATAL,
+    'ERROR': ERROR,
+    'WARN': WARNING,
+    'WARNING': WARNING,
+    'INFO': INFO,
+    'DEBUG': DEBUG,
+    'NOTSET': NOTSET,
+}
+
+def getLevelName(level):
+    """
+    Return the textual representation of logging level 'level'.
+
+    If the level is one of the predefined levels (CRITICAL, ERROR, WARNING,
+    INFO, DEBUG) then you get the corresponding string. If you have
+    associated levels with names using addLevelName then the name you have
+    associated with 'level' is returned.
+
+    If a numeric value corresponding to one of the defined levels is passed
+    in, the corresponding string representation is returned.
+
+    Otherwise, the string "Level %s" % level is returned.
+    """
+    # See Issues #22386 and #27937 for why it's this way
+    return (_levelToName.get(level) or _nameToLevel.get(level) or
+                    "Level {}".format(level) )
+
+def addLevelName(level, levelName):
+    """
+    Associate 'levelName' with 'level'.
+
+    This is used when converting levels to text during message formatting.
+    """
+    _acquireLock()
+    try:        #unlikely to cause an exception, but you never know...
+        _levelToName[level] = levelName
+        _nameToLevel[levelName] = level
+    except Exception as exc: # @note - this is a hack around bug in transcrypt
+        raise exc
+    finally:
+        _releaseLock()
+
+# @note - We currently don't have this functionality
+#        but it could be added in the future because the
+#        javascript stack is available in exception. Matching this
+#        to the python info will be difficult though.
+# if hasattr(sys, '_getframe'):
+#           currentframe = lambda: sys._getframe(3)
+# else: #pragma: no cover
+#           def currentframe():
+#                   """Return the frame object for the caller's stack frame."""
+#                   try:
+#                           raise Exception
+#                   except Exception:
+#                           return sys.exc_info()[2].tb_frame.f_back
+
+def currentframe():
+    return(None)
+
+#
+# _srcfile is used when walking the stack to check when we've got the first
+# caller stack frame, by skipping frames whose filename is that of this
+# module's source. It therefore should contain the filename of this module's
+# source file.
+#
+# Ordinarily we would use __file__ for this, but frozen modules don't always
+# have __file__ set, for some reason (see Issue #21736). Thus, we get the
+# filename from a handy code object from a function defined in this module.
+# (There's no particular reason for picking addLevelName.)
+#
+
+# @note - this is not going to work
+#_srcfile = os.path.normcase(addLevelName.__code__.co_filename)
+
+# _srcfile is only used in conjunction with sys._getframe().
+# To provide compatibility with older versions of Python, set _srcfile
+# to None if _getframe() is not available; this value will prevent
+# findCaller() from being called. You can also do this if you want to avoid
+# the overhead of fetching caller information, even when _getframe() is
+# available.
+#if not hasattr(sys, '_getframe'):
+#        _srcfile = None
+
+_srcfile = None
+
+def _checkLevel(level):
+    if isinstance(level, int):
+        rv = level
+    elif str(level) == level:
+        if level not in _nameToLevel:
+            raise ValueError("Unknown level: {}".format(level))
+        rv = _nameToLevel[level]
+    else:
+        raise TypeError("Level not an integer or a valid string: {}".format(level))
+    return rv
+
+#---------------------------------------------------------------------------
+#       Thread-related stuff
+#---------------------------------------------------------------------------
+
+#
+#_lock is used to serialize access to shared data structures in this module.
+#This needs to be an RLock because fileConfig() creates and configures
+#Handlers, and so might arbitrary user threads. Since Handler code updates the
+#shared dictionary _handlers, it needs to acquire the lock. But if configuring,
+#the lock would already have been acquired - so we need an RLock.
+#The same argument applies to Loggers and Manager.loggerDict.
+#
+#if threading:
+#        _lock = threading.RLock()
+#else: #pragma: no cover
+
+# There is no Threading Module so we will disable this by default
+# @note future optimization - remove lock methods altogether.
+_lock = None
+
+# @note I've left the a acquire/release methods in case there
+#   is a case in the future where a web worker background thread
+#   might be available
+def _acquireLock():
+    """
+    Acquire the module-level lock for serializing access to shared data.
+
+    This should be released with _releaseLock().
+    """
+    if _lock:
+        _lock.acquire()
+
+def _releaseLock():
+    """
+    Release the module-level lock acquired by calling _acquireLock().
+    """
+    if _lock:
+        _lock.release()
+
+#---------------------------------------------------------------------------
+#       The logging record
+#---------------------------------------------------------------------------
+
+class LogRecord(object):
+    """
+    A LogRecord instance represents an event being logged.
+
+    LogRecord instances are created every time something is logged. They
+    contain all the information pertinent to the event being logged. The
+    main information passed in is in msg and args, which are combined
+    using str(msg) % args to create the message field of the record. The
+    record also includes information such as when the record was created,
+    the source line where the logging call was made, and any exception
+    information to be logged.
+    """
+    def __init__(self, name, level, pathname, lineno,
+                             msg, args, exc_info, func=None, sinfo=None, **kwargs):
+        """
+        Initialize a logging record with interesting information.
+        """
+        ct = time.time()
+        self.name = name
+        self.msg = msg
+        #
+        # The following statement allows passing of a dictionary as a sole
+        # argument, so that you can do something like
+        #    logging.debug("a %(a)d b %(b)s", {'a':1, 'b':2})
+        # Suggested by Stefan Behnel.
+        # Note that without the test for args[0], we get a problem because
+        # during formatting, we test to see if the arg is present using
+        # 'if self.args:'. If the event being logged is e.g. 'Value is %d'
+        # and if the passed arg fails 'if self.args:' then no formatting
+        # is done. For example, logger.warning('Value is %d', 0) would log
+        # 'Value is %d' instead of 'Value is 0'.
+        # For the use case of passing a dictionary, this should not be a
+        # problem.
+        # Issue #21172: a request was made to relax the isinstance check
+        # to hasattr(args[0], '__getitem__'). However, the docs on string
+        # formatting still seem to suggest a mapping object is required.
+        # Thus, while not removing the isinstance check, it does now look
+        # for collections.Mapping rather than, as before, dict.
+
+
+        if (args and len(args) == 1 and isinstance(args[0], collections.Mapping)
+                and args[0]):
+            # @note - we can't manage these kind of logging args
+            #       so we don't try
+            #args = args[0]
+            if ( raiseExceptions ):
+                raise NotImplementedError("No Dict Args to Log Record")
+
+        self.args = args
+        self.levelname = getLevelName(level)
+        self.levelno = level
+        self.pathname = pathname
+        # @note - currently we don't have os.path
+        #       so we are going to ignore this
+        # try:
+        #           self.filename = os.path.basename(pathname)
+        #           self.module = os.path.splitext(self.filename)[0]
+        # except (TypeError, ValueError, AttributeError):
+        #           self.filename = pathname
+        #           self.module = "Unknown module"
+        self.filename = pathname
+        self.module = "Unknown module"
+
+        self.exc_info = exc_info
+        self.exc_text = None            # used to cache the traceback text
+        self.stack_info = sinfo
+        self.lineno = lineno
+        self.funcName = func
+        self.created = ct
+        self.msecs = (ct - int(ct)) * 1000
+        self.relativeCreated = (self.created - _startTime) * 1000
+        # @note - We have no threading interface so we are going
+        #        to set default values here to prevent bad behavior
+        # if logThreads and threading:
+        #           self.thread = threading.get_ident()
+        #           self.threadName = threading.current_thread().name
+        # else: # pragma: no cover
+        #           self.thread = None
+        #           self.threadName = None
+        self.thread = None
+        self.threadName = None
+
+        # @note - No Multiprocessing - we will err on the
+        #        side of caution
+        # if not logMultiprocessing: # pragma: no cover
+        #           self.processName = None
+        # else:
+        #           self.processName = 'MainProcess'
+        #           mp = sys.modules.get('multiprocessing')
+        #           if mp is not None:
+        #                   # Errors may occur if multiprocessing has not finished loading
+        #                   # yet - e.g. if a custom import hook causes third-party code
+        #                   # to run when multiprocessing calls import. See issue 8200
+        #                   # for an example
+        #                   try:
+        #                           self.processName = mp.current_process().name
+        #                   except Exception: #pragma: no cover
+        #                           pass
+        self.processName = None
+
+        # if logProcesses and hasattr(os, 'getpid'):
+        #           self.process = os.getpid()
+        # else:
+        #           self.process = None
+        self.process = None
+
+    def getMessage(self):
+        """
+        Return the message for this LogRecord.
+
+        Return the message for this LogRecord after merging any
+        user-supplied arguments with the message.
+        """
+        msg = str(self.msg)
+        if self.args:
+            msg = msg.format(*self.args)
+        return msg
+
+    def toDict(self):
+        """ Utility method to convert the LogRecord object into a
+        an object that can be passed to the str.format function.
+        This is needed to allow for named string format arguments.
+        @note - if you create a new LogRecord object type, then
+           you will likely want to override this method to add
+           more keys to the returned dict
+        """
+        keysToPick=[
+            "name", "msg", "levelname", "levelno", "pathname",
+            "filename", "module", "lineno", "funcName", "created",
+            "asctime", "msecs", "relativeCreated", "thread", "threadName",
+            "process"
+            ]
+
+        ret = {}
+        for k in keysToPick:
+            if ( k == "name" ):
+                # This is a hack - name seems to be owned by the
+                # class -- and evals to "cls" and the key "name" gets
+                # replaced by the key "py_name" in javascript
+                ret[k] = getattr(self, "py_name", None)
+            else:
+                ret[k] = getattr(self, k, None)
+        ret["message"] = self.getMessage()
+        return(ret)
+
+
+    def __str__(self):
+        return '<LogRecord: {}, {}, {}, {}, "{}">'.format(
+            self.name, self.levelno,
+            self.pathname, self.lineno, self.msg)
+
+    def __repr__(self):
+        return(str(self))
+
+
+#
+#       Determine which class to use when instantiating log records.
+#
+_logRecordFactory = LogRecord
+
+def setLogRecordFactory(factory):
+    """
+    Set the factory to be used when instantiating a log record.
+
+    :param factory: A callable which will be called to instantiate
+    a log record.
+    """
+    global _logRecordFactory
+    _logRecordFactory = factory
+
+def getLogRecordFactory():
+    """
+    Return the factory to be used when instantiating a log record.
+    """
+
+    return _logRecordFactory
+
+def makeLogRecord(dict):
+    """
+    Make a LogRecord whose attributes are defined by the specified dictionary,
+    This function is useful for converting a logging event received over
+    a socket connection (which is sent as a dictionary) into a LogRecord
+    instance.
+    """
+    rv = _logRecordFactory(None, None, "", 0, "", (), None, None)
+    rv.__dict__.update(dict)
+    return rv
+
+#---------------------------------------------------------------------------
+#       Formatter classes and functions
+#---------------------------------------------------------------------------
+
+# @note - this requires string.Template which we need
+#        to confirm is available - the % operator I don't think is
+#        implemented for strings in transcrypt at this point.
+class PercentStyle(object):
+    default_format = '%(message)s'
+    asctime_format = '%(asctime)s'
+    asctime_search = '%(asctime)'
+
+    def __init__(self, fmt):
+        self._fmt = fmt or self.default_format
+
+    def usesTime(self):
+        return self._fmt.find(self.asctime_search) >= 0
+
+    def format(self, record):
+        return self._fmt % record.__dict__
+
+### I think we are going to have to restrict to use this
+#    type unless we can find the other is available
+class StrFormatStyle(PercentStyle):
+    default_format = '{message}'
+    asctime_format = '{asctime}'
+    asctime_search = '{asctime' # @question is this right ?
+
+    __pragma__('kwargs')
+    def format(self, record):
+
+        return self._fmt.format(**(record.toDict()))
+    __pragma__('nokwargs')
+
+# Again - I don't think we have the implementation for this type
+#        yet.
+class StringTemplateStyle(PercentStyle):
+    default_format = '${message}'
+    asctime_format = '${asctime}'
+    asctime_search = '${asctime}'
+
+    def __init__(self, fmt):
+        self._fmt = fmt or self.default_format
+        self._tpl = Template(self._fmt)
+
+    def usesTime(self):
+        fmt = self._fmt
+        return fmt.find('$asctime') >= 0 or fmt.find(self.asctime_format) >= 0
+
+    __pragma__('kwargs')
+    def format(self, record):
+        return self._tpl.substitute(**record.__dict__)
+    __pragma__('nokwargs')
+
+BASIC_FORMAT = '{levelname}:{name}:{message}'
+#BASIC_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+_STYLES = {
+#   '%': (PercentStyle, "%(levelname)s:%(name)s:%(message)s"),
+    '{': (StrFormatStyle, BASIC_FORMAT),
+#   '$': (StringTemplateStyle, '${levelname}:${name}:${message}'),
+}
+
+class Formatter(object):
+    """
+    Formatter instances are used to convert a LogRecord to text.
+
+    Formatters need to know how a LogRecord is constructed. They are
+    responsible for converting a LogRecord to (usually) a string which can
+    be interpreted by either a human or an external system. The base Formatter
+    allows a formatting string to be specified. If none is supplied, the
+    default value of "%s(message)" is used.
+
+    The Formatter can be initialized with a format string which makes use of
+    knowledge of the LogRecord attributes - e.g. the default value mentioned
+    above makes use of the fact that the user's message and arguments are pre-
+    formatted into a LogRecord's message attribute. Currently, the useful
+    attributes in a LogRecord are described by:
+
+    %(name)s                        Name of the logger (logging channel)
+    %(levelno)s                 Numeric logging level for the message (DEBUG, INFO,
+                                                WARNING, ERROR, CRITICAL)
+    %(levelname)s               Text logging level for the message ("DEBUG", "INFO",
+                                                "WARNING", "ERROR", "CRITICAL")
+    %(pathname)s                Full pathname of the source file where the logging
+                                                call was issued (if available)
+    %(filename)s                Filename portion of pathname
+    %(module)s                  Module (name portion of filename)
+    %(lineno)d                  Source line number where the logging call was issued
+                                                (if available)
+    %(funcName)s                Function name
+    %(created)f                 Time when the LogRecord was created (time.time()
+                                                return value)
+    %(asctime)s                 Textual time when the LogRecord was created
+    %(msecs)d                       Millisecond portion of the creation time
+    %(relativeCreated)d Time in milliseconds when the LogRecord was created,
+                                                relative to the time the logging module was loaded
+                                                (typically at application startup time)
+    %(thread)d                  Thread ID (if available)
+    %(threadName)s          Thread name (if available)
+    %(process)d                 Process ID (if available)
+    %(message)s                 The result of record.getMessage(), computed just as
+                                                the record is emitted
+    """
+
+    converter = time.localtime
+    __pragma__('kwargs')
+    def __init__(self, fmt=None, datefmt=None, style='{'):
+        """
+        Initialize the formatter with specified format strings.
+
+        Initialize the formatter either with the specified format string, or a
+        default as described above. Allow for specialized date formatting with
+        the optional datefmt argument (if omitted, you get the ISO8601 format).
+
+        Use a style parameter of '%', '{' or '$' to specify that you want to
+        use one of %-formatting, :meth:`str.format` (``{}``) formatting or
+        :class:`string.Template` formatting in your format string.
+
+        .. versionchanged:: 3.2
+        Added the ``style`` parameter.
+        """
+        # if style not in _STYLES:
+        #   raise ValueError('Style must be one of: {}'.format(','.join(_STYLES.keys())))
+        if ( style != '{' ):
+            raise NotImplementedError("{} format only")
+
+        self._style = _STYLES[style][0](fmt)
+        self._fmt = self._style._fmt
+        self.datefmt = datefmt
+
+    __pragma__('nokwargs')
+
+    default_time_format = '%Y-%m-%d %H:%M:%S'
+    default_msec_format = '{},{:03d}'
+
+
+    def formatTime(self, record, datefmt=None):
+        """
+        Return the creation time of the specified LogRecord as formatted text.
+
+        This method should be called from format() by a formatter which
+        wants to make use of a formatted time. This method can be overridden
+        in formatters to provide for any specific requirement, but the
+        basic behaviour is as follows: if datefmt (a string) is specified,
+        it is used with time.strftime() to format the creation time of the
+        record. Otherwise, the ISO8601 format is used. The resulting
+        string is returned. This function uses a user-configurable function
+        to convert the creation time to a tuple. By default, time.localtime()
+        is used; to change this for a particular formatter instance, set the
+        'converter' attribute to a function with the same signature as
+        time.localtime() or time.gmtime(). To change it for all formatters,
+        for example if you want all logging times to be shown in GMT,
+        set the 'converter' attribute in the Formatter class.
+        """
+        ct = self.converter(record.created)
+        if datefmt:
+            s = time.strftime(datefmt, ct)
+        else:
+            t = time.strftime(self.default_time_format, ct)
+            s = self.default_msec_format % (t, record.msecs)
+        return s
+
+    def formatException(self, ei):
+        """
+        Format and return the specified exception information as a string.
+
+        This default implementation just uses
+        traceback.print_exception()
+        """
+        # @todo - we need to fix this -
+        return( str(ei) )
+        # sio = io.StringIO()
+        # tb = ei[2]
+        # # See issues #9427, #1553375. Commented out for now.
+        # #if getattr(self, 'fullstack', False):
+        # #      traceback.print_stack(tb.tb_frame.f_back, file=sio)
+        # traceback.print_exception(ei[0], ei[1], tb, None, sio)
+        # s = sio.getvalue()
+        # sio.close()
+        # if s[-1:] == "\n":
+        #           s = s[:-1]
+        # return s
+
+    def usesTime(self):
+        """
+        Check if the format uses the creation time of the record.
+        """
+        return self._style.usesTime()
+
+    def formatMessage(self, record):
+        return self._style.format(record)
+
+    def formatStack(self, stack_info):
+        """
+        This method is provided as an extension point for specialized
+        formatting of stack information.
+
+        The input data is a string as returned from a call to
+        :func:`traceback.print_stack`, but with the last trailing newline
+        removed.
+
+        The base implementation just returns the value passed in.
+        """
+        return stack_info
+
+    def format(self, record):
+        """
+        Format the specified record as text.
+
+        The record's attribute dictionary is used as the operand to a
+        string formatting operation which yields the returned string.
+        Before formatting the dictionary, a couple of preparatory steps
+        are carried out. The message attribute of the record is computed
+        using LogRecord.getMessage(). If the formatting string uses the
+        time (as determined by a call to usesTime(), formatTime() is
+        called to format the event time. If there is exception information,
+        it is formatted using formatException() and appended to the message.
+        """
+        record.message = record.getMessage()
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+        s = self.formatMessage(record)
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if s[len(s)-1] != "\n":
+                s = s + "\n"
+                s = s + record.exc_text
+        if record.stack_info:
+            if s[len(s)-1] != "\n":
+                s = s + "\n"
+                s = s + self.formatStack(record.stack_info)
+        return s
+
+#
+#       The default formatter to use when no other is specified
+#
+_defaultFormatter = Formatter()
+
+class BufferingFormatter(object):
+    """
+    A formatter suitable for formatting a number of records.
+    """
+    def __init__(self, linefmt=None):
+        """
+        Optionally specify a formatter which will be used to format each
+        individual record.
+        """
+        if linefmt:
+            self.linefmt = linefmt
+        else:
+            self.linefmt = _defaultFormatter
+
+    def formatHeader(self, records):
+        """
+        Return the header string for the specified records.
+        """
+        return ""
+
+    def formatFooter(self, records):
+        """
+        Return the footer string for the specified records.
+        """
+        return ""
+
+    def format(self, records):
+        """
+        Format the specified records and return the result as a string.
+        """
+        rv = ""
+        if len(records) > 0:
+            rv = rv + self.formatHeader(records)
+            for record in records:
+                rv = rv + self.linefmt.format(record)
+                rv = rv + self.formatFooter(records)
+        return rv
+
+#---------------------------------------------------------------------------
+#       Filter classes and functions
+#---------------------------------------------------------------------------
+
+class Filter(object):
+    """
+    Filter instances are used to perform arbitrary filtering of LogRecords.
+
+    Loggers and Handlers can optionally use Filter instances to filter
+    records as desired. The base filter class only allows events which are
+    below a certain point in the logger hierarchy. For example, a filter
+    initialized with "A.B" will allow events logged by loggers "A.B",
+    "A.B.C", "A.B.C.D", "A.B.D" etc. but not "A.BB", "B.A.B" etc. If
+    initialized with the empty string, all events are passed.
+    """
+    def __init__(self, name=''):
+        """
+        Initialize a filter.
+
+        Initialize with the name of the logger which, together with its
+        children, will have its events allowed through the filter. If no
+        name is specified, allow every event.
+        """
+        self.name = name
+        self.nlen = len(name)
+
+    def filter(self, record):
+        """
+        Determine if the specified record is to be logged.
+
+        Is the specified record to be logged? Returns 0 for no, nonzero for
+        yes. If deemed appropriate, the record may be modified in-place.
+        """
+        if self.nlen == 0:
+            return True
+        elif self.name == record.name:
+            return True
+        elif record.name.find(self.name, 0, self.nlen) != 0:
+            return False
+        return (record.name[self.nlen] == ".")
+
+class Filterer(object):
+    """
+    A base class for loggers and handlers which allows them to share
+    common code.
+    """
+    def __init__(self):
+        """
+        Initialize the list of filters to be an empty list.
+        """
+        self.filters = []
+
+    def addFilter(self, filt):
+        """
+        Add the specified filter to this handler.
+        """
+        if not (filt in self.filters):
+            self.filters.append(filt)
+
+    def removeFilter(self, filt):
+        """
+        Remove the specified filter from this handler.
+        """
+        if filt in self.filters:
+            self.filters.remove(filt)
+
+    def filter(self, record):
+        """
+        Determine if a record is loggable by consulting all the filters.
+
+        The default is to allow the record to be logged; any filter can veto
+        this and the record is then dropped. Returns a zero value if a record
+        is to be dropped, else non-zero.
+
+        .. versionchanged:: 3.2
+
+        Allow filters to be just callables.
+        """
+        rv = True
+        for f in self.filters:
+            if hasattr(f, 'filter'):
+                result = f.filter(record)
+            else:
+                result = f(record) # assume callable - will raise if not
+            if not result:
+                rv = False
+                break
+        return rv
+
+########################
+# Default Logging Stream
+########################
+# This is temporary until we
+# get a "sys.stderr" stream object that
+# we can target.
+
+class ConsoleLogStream(object):
+    """ This implements a quasi "Stream" like object for mimicing
+    the sys.stderr object.
+    """
+    def __init__(self):
+        self.name = "console"
+
+    def write(self, msg):
+        """
+        """
+        # The console puts a new line in for us so we
+        # need to strip off the newlines in order for
+        # the formatting to seem reasonable.
+        msg = msg.rstrip('\n\r')
+        if ( len(msg) > 0 ):
+            console.log(msg)
+
+_consoleStream = ConsoleLogStream()
+
+
+#---------------------------------------------------------------------------
+#       Handler classes and functions
+#---------------------------------------------------------------------------
+
+#map of handler names to handlers
+_handlers = {}
+# @todo - investigate if javascript has something like this and
+#    whether we care or want to use it.
+#_handlers = weakref.WeakValueDictionary()
+
+# added to allow handlers to be removed in reverse of order initialized
+_handlerList = []
+
+def _removeHandlerRef(wr):
+    """
+    Remove a handler reference from the internal cleanup list.
+    """
+    # This function can be called during module teardown, when globals are
+    # set to None. It can also be called from another thread. So we need to
+    # pre-emptively grab the necessary globals and check if they're None,
+    # to prevent race conditions and failures during interpreter shutdown.
+    acquire, release, handlers = _acquireLock, _releaseLock, _handlerList
+    if acquire and release and handlers:
+        acquire()
+        try:
+            if wr in handlers:
+                handlers.remove(wr)
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            release()
+
+def _addHandlerRef(handler):
+    """
+    Add a handler to the internal cleanup list using a weak reference.
+    """
+    _acquireLock()
+    try:
+        _handlerList.append(handler)
+#        _handlerList.append(weakref.ref(handler, _removeHandlerRef))
+    except Exception as exc: # @note - this is a hack around bug in transcrypt
+        raise exc
+    finally:
+        _releaseLock()
+
+class Handler(Filterer):
+    """
+    Handler instances dispatch logging events to specific destinations.
+
+    The base handler class. Acts as a placeholder which defines the Handler
+    interface. Handlers can optionally use Formatter instances to format
+    records as desired. By default, no formatter is specified; in this case,
+    the 'raw' message as determined by record.message is logged.
+    """
+    def __init__(self, level=NOTSET):
+        """
+        Initializes the instance - basically setting the formatter to None
+        and the filter list to empty.
+        """
+        Filterer.__init__(self)
+        self._name = None
+        self.level = _checkLevel(level)
+        self.formatter = None
+        # Add the handler to the global _handlerList (for cleanup on shutdown)
+        _addHandlerRef(self)
+        self.createLock()
+
+    def get_name(self):
+        return self._name
+
+    def set_name(self, name):
+        _acquireLock()
+        try:
+            if self._name in _handlers:
+                del _handlers[self._name]
+            self._name = name
+            if name:
+                _handlers[name] = self
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            _releaseLock()
+
+    name = property(get_name, set_name)
+
+    def createLock(self):
+        """
+        Acquire a thread lock for serializing access to the underlying I/O.
+        """
+        # No Threading so we set a default value here
+        # if threading:
+        #           self.lock = threading.RLock()
+        # else: #pragma: no cover
+        #           self.lock = None
+        self.lock = None
+
+    def acquire(self):
+        """
+        Acquire the I/O thread lock.
+        """
+        if self.lock:
+            self.lock.acquire()
+
+    def release(self):
+        """
+        Release the I/O thread lock.
+        """
+        if self.lock:
+            self.lock.release()
+
+    def setLevel(self, level):
+        """
+        Set the logging level of this handler.  level must be an int or a str.
+        """
+        self.level = _checkLevel(level)
+
+    def format(self, record):
+        """
+        Format the specified record.
+
+        If a formatter is set, use it. Otherwise, use the default formatter
+        for the module.
+        """
+        if self.formatter:
+            fmt = self.formatter
+        else:
+            fmt = _defaultFormatter
+        return fmt.format(record)
+
+    def emit(self, record):
+        """
+        Do whatever it takes to actually log the specified logging record.
+
+        This version is intended to be implemented by subclasses and so
+        raises a NotImplementedError.
+        """
+        raise NotImplementedError("Must be implemented by handler")
+
+    def handle(self, record):
+        """
+        Conditionally emit the specified logging record.
+
+        Emission depends on filters which may have been added to the handler.
+        Wrap the actual emission of the record with acquisition/release of
+        the I/O thread lock. Returns whether the filter passed the record for
+        emission.
+        """
+        rv = self.filter(record)
+        if rv:
+            self.acquire()
+            try:
+                self.emit(record)
+            except Exception as exc: # @note - this is a hack around bug in transcrypt
+                raise exc
+
+            finally:
+                self.release()
+        return rv
+
+    def setFormatter(self, fmt):
+        """
+        Set the formatter for this handler.
+        """
+        self.formatter = fmt
+
+    def flush(self):
+        """
+        Ensure all logging output has been flushed.
+
+        This version does nothing and is intended to be implemented by
+        subclasses.
+        """
+        pass
+
+    def close(self):
+        """
+        Tidy up any resources used by the handler.
+
+        This version removes the handler from an internal map of handlers,
+        _handlers, which is used for handler lookup by name. Subclasses
+        should ensure that this gets called from overridden close()
+        methods.
+        """
+        #get the module data lock, as we're updating a shared structure.
+        _acquireLock()
+        try:        #unlikely to raise an exception, but you never know...
+            if self._name and self._name in _handlers:
+                del _handlers[self._name]
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            _releaseLock()
+
+    def handleError(self, record):
+        """
+        Handle errors which occur during an emit() call.
+
+        This method should be called from handlers when an exception is
+        encountered during an emit() call. If raiseExceptions is false,
+        exceptions get silently ignored. This is what is mostly wanted
+        for a logging system - most users will not care about errors in
+        the logging system, they are more interested in application errors.
+        You could, however, replace this with a custom handler if you wish.
+        The record which was being processed is passed in to this method.
+        """
+        if ( raiseExceptions ):
+            raise Exception("Failed to log: {}".format(record))
+        else:
+            _consoleStream.write("--- Logging Error ---\n")
+
+    def __repr__(self):
+        level = getLevelName(self.level)
+        return '<{} ({})>'.format(self.__class__.__name__, level)
+
+class StreamHandler(Handler):
+    """
+    A handler class which writes logging records, appropriately formatted,
+    to a stream. Note that this class does not close the stream, as
+    sys.stdout or sys.stderr may be used.
+    """
+
+    terminator = '\n'
+
+    def __init__(self, stream=None, level=NOTSET):
+        """
+        Initialize the handler.
+
+        If stream is not specified, sys.stderr is used.
+        """
+        Handler.__init__(self, level)
+        if stream is None:
+            stream = _consoleStream
+        self.stream = stream
+
+    def flush(self):
+        """
+        Flushes the stream.
+        """
+        self.acquire()
+        try:
+            if self.stream and hasattr(self.stream, "flush"):
+                self.stream.flush()
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            self.release()
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        If a formatter is specified, it is used to format the record.
+        The record is then written to the stream with a trailing newline.    If
+        exception information is present, it is formatted using
+        traceback.print_exception and appended to the stream.    If the stream
+        has an 'encoding' attribute, it is used to determine how to do the
+        output to the stream.
+        """
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            stream.write(msg)
+            stream.write(self.terminator)
+            self.flush()
+        except Exception:
+            self.handleError(record)
+
+    def __repr__(self):
+        level = getLevelName(self.level)
+        name = getattr(self.stream, 'name', '')
+        if name:
+            name += ' '
+        return '<{} {}({})>'.format(self.__class__.__name__, name, level)
+
+class FileHandler(StreamHandler):
+    """ Handler Class that is suppose to write to disk - we haven't
+    implemented this in transcrypt.
+    """
+    def __init__(self, filename, mode='a', encoding=None, delay=False):
+        """
+        """
+        raise NotImplementedError("No Filesystem for FileHandler")
+
+class _StderrHandler(StreamHandler):
+    """
+    This class is like a StreamHandler using sys.stderr, but always uses
+    whatever sys.stderr is currently set to rather than the value of
+    sys.stderr at handler construction time.
+    """
+    def __init__(self, level=NOTSET):
+        """
+        Initialize the handler.
+        """
+        StreamHandler.__init__(self, None, level)
+
+    def _getStream(self):
+        return _consoleStream
+
+    stream = property(_getStream)
+
+
+_defaultLastResort = _StderrHandler(WARNING)
+lastResort = _defaultLastResort
+
+#---------------------------------------------------------------------------
+#       Manager classes and functions
+#---------------------------------------------------------------------------
+
+class PlaceHolder(object):
+    """
+    PlaceHolder instances are used in the Manager logger hierarchy to take
+    the place of nodes for which no loggers have been defined. This class is
+    intended for internal use only and not as part of the public API.
+    """
+    def __init__(self, alogger):
+        """
+        Initialize with the specified logger being a child of this placeholder.
+        """
+        self.loggerMap = { alogger : None }
+
+    def append(self, alogger):
+        """
+        Add the specified logger as a child of this placeholder.
+        """
+        if alogger not in self.loggerMap:
+            self.loggerMap[alogger] = None
+
+#
+#       Determine which class to use when instantiating loggers.
+#
+
+def setLoggerClass(klass):
+    """
+    Set the class to be used when instantiating a logger. The class should
+    define __init__() such that only a name argument is required, and the
+    __init__() should call Logger.__init__()
+    """
+    if klass != Logger:
+        if not issubclass(klass, Logger):
+            raise TypeError("logger not derived from logging.Logger: "
+                                            + klass.__name__)
+    global _loggerClass
+    _loggerClass = klass
+
+def getLoggerClass():
+    """
+    Return the class to be used when instantiating a logger.
+    """
+    return _loggerClass
+
+class Manager(object):
+    """
+    There is [under normal circumstances] just one Manager instance, which
+    holds the hierarchy of loggers.
+    """
+    def __init__(self, rootnode):
+        """
+        Initialize the manager with the root node of the logger hierarchy.
+        """
+        self.root = rootnode
+        self.disable = 0
+        self.emittedNoHandlerWarning = False
+        self.loggerDict = {}
+        self.loggerClass = None
+        self.logRecordFactory = None
+
+    def getLogger(self, name):
+        """
+        Get a logger with the specified name (channel name), creating it
+        if it doesn't yet exist. This name is a dot-separated hierarchical
+        name, such as "a", "a.b", "a.b.c" or similar.
+
+        If a PlaceHolder existed for the specified name [i.e. the logger
+        didn't exist but a child of it did], replace it with the created
+        logger and fix up the parent/child references which pointed to the
+        placeholder to now point to the logger.
+        """
+        rv = None
+        if not isinstance(name, str):
+            raise TypeError('A logger name must be a string')
+        _acquireLock()
+        try:
+            if name in self.loggerDict:
+                rv = self.loggerDict[name]
+                if isinstance(rv, PlaceHolder):
+                    ph = rv
+                    rv = (self.loggerClass or _loggerClass)(name)
+                    rv.manager = self
+                    self.loggerDict[name] = rv
+                    self._fixupChildren(ph, rv)
+                    self._fixupParents(rv)
+            else:
+                rv = (self.loggerClass or _loggerClass)(name)
+                rv.manager = self
+                self.loggerDict[name] = rv
+                self._fixupParents(rv)
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            _releaseLock()
+        return rv
+
+    def setLoggerClass(self, klass):
+        """
+        Set the class to be used when instantiating a logger with this Manager.
+        """
+        if klass != Logger:
+            if not issubclass(klass, Logger):
+                raise TypeError("logger not derived from logging.Logger: "
+                                                + klass.__name__)
+        self.loggerClass = klass
+
+    def setLogRecordFactory(self, factory):
+        """
+        Set the factory to be used when instantiating a log record with this
+        Manager.
+        """
+        self.logRecordFactory = factory
+
+    def _fixupParents(self, alogger):
+        """
+        Ensure that there are either loggers or placeholders all the way
+        from the specified logger to the root of the logger hierarchy.
+        """
+        name = alogger.name
+        i = name.rfind(".")
+        rv = None
+        while (i > 0) and not rv:
+            substr = name[:i]
+            if substr not in self.loggerDict:
+                self.loggerDict[substr] = PlaceHolder(alogger)
+            else:
+                obj = self.loggerDict[substr]
+                if isinstance(obj, Logger):
+                    rv = obj
+                else:
+                    assert isinstance(obj, PlaceHolder)
+                    obj.append(alogger)
+            i = name.rfind(".", 0, i - 1)
+        if not rv:
+            rv = self.root
+        alogger.parent = rv
+
+    def _fixupChildren(self, ph, alogger):
+        """
+        Ensure that children of the placeholder ph are connected to the
+        specified logger.
+        """
+        name = alogger.name
+        namelen = len(name)
+        for c in ph.loggerMap.keys():
+            #The if means ... if not c.parent.name.startswith(nm)
+            if c.parent.name[:namelen] != name:
+                alogger.parent = c.parent
+                c.parent = alogger
+
+#---------------------------------------------------------------------------
+#       Logger classes and functions
+#---------------------------------------------------------------------------
+
+
+class Logger(Filterer):
+    """
+    Instances of the Logger class represent a single logging channel. A
+    "logging channel" indicates an area of an application. Exactly how an
+    "area" is defined is up to the application developer. Since an
+    application can have any number of areas, logging channels are identified
+    by a unique string. Application areas can be nested (e.g. an area
+    of "input processing" might include sub-areas "read CSV files", "read
+    XLS files" and "read Gnumeric files"). To cater for this natural nesting,
+    channel names are organized into a namespace hierarchy where levels are
+    separated by periods, much like the Java or Python package namespace. So
+    in the instance given above, channel names might be "input" for the upper
+    level, and "input.csv", "input.xls" and "input.gnu" for the sub-levels.
+    There is no arbitrary limit to the depth of nesting.
+    """
+    def __init__(self, name, level=NOTSET):
+        """
+        Initialize the logger with a name and an optional level.
+        """
+        Filterer.__init__(self)
+        self.name = name
+        self.level = _checkLevel(level)
+        self.parent = None
+        self.propagate = True
+        self.handlers = []
+        self.disabled = False
+
+    def setLevel(self, level):
+        """
+        Set the logging level of this logger.    level must be an int or a str.
+        """
+        self.level = _checkLevel(level)
+
+    __pragma__('kwargs')
+    def debug(self, msg, *args, **kwargs):
+        """
+        Log 'msg.format(args)' with severity 'DEBUG'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.debug("Houston, we have a {}", "thorny problem", exc_info=1)
+        """
+        if self.isEnabledFor(DEBUG):
+            self._log(DEBUG, msg, args, **kwargs)
+
+    def info(self, msg, *args, **kwargs):
+        """
+        Log 'msg.format(args)' with severity 'INFO'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.info("Houston, we have a {}", "interesting problem", exc_info=1)
+        """
+        if self.isEnabledFor(INFO):
+            self._log(INFO, msg, args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """
+        Log 'msg.format(args)' with severity 'WARNING'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.warning("Houston, we have a {}", "bit of a problem", exc_info=1)
+        """
+        if self.isEnabledFor(WARNING):
+            self._log(WARNING, msg, args, **kwargs)
+
+    def warn(self, msg, *args, **kwargs):
+        # @note - we don't have a warnings module
+        #warnings.warn("The 'warn' method is deprecated, "
+        #                           "use 'warning' instead", DeprecationWarning, 2)
+        self.warning(msg, *args, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        """
+        Log 'msg.format(args)' with severity 'ERROR'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.error("Houston, we have a {}", "major problem", exc_info=1)
+        """
+        if self.isEnabledFor(ERROR):
+            self._log(ERROR, msg, args, **kwargs)
+
+    def exception(self, msg, *args, exc_info=True, **kwargs):
+        """
+        Convenience method for logging an ERROR with exception information.
+        """
+        self.error(msg, *args, exc_info=exc_info, **kwargs)
+
+    def critical(self, msg, *args, **kwargs):
+        """
+        Log 'msg.format(args)' with severity 'CRITICAL'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.critical("Houston, we have a {}", "major disaster", exc_info=1)
+        """
+        if self.isEnabledFor(CRITICAL):
+            self._log(CRITICAL, msg, args, **kwargs)
+
+        fatal = critical
+
+    def log(self, level, msg, *args, **kwargs):
+        """
+        Log 'msg.format(args)' with the integer severity 'level'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.log(level, "We have a {}", "mysterious problem", exc_info=1)
+        """
+        if not isinstance(level, int):
+            if raiseExceptions:
+                raise TypeError("level must be an integer")
+            else:
+                return
+        if self.isEnabledFor(level):
+            self._log(level, msg, args, **kwargs)
+
+    __pragma__ ('nokwargs')
+
+    def findCaller(self, stack_info=False):
+        """
+        Find the stack frame of the caller so that we can note the source
+        file name, line number and function name.
+        """
+        f = currentframe()
+        #On some versions of IronPython, currentframe() returns None if
+        #IronPython isn't run with -X:Frames.
+        # if f is not None:
+        #           f = f.f_back
+
+        rv = "(unknown file)", 0, "(unknown function)", None
+
+        # while hasattr(f, "f_code"):
+        #           co = f.f_code
+        #           filename = os.path.normcase(co.co_filename)
+        #           if filename == _srcfile:
+        #                   f = f.f_back
+        #                   continue
+        #           sinfo = None
+        #           if stack_info:
+        #                   sio = io.StringIO()
+        #                   sio.write('Stack (most recent call last):\n')
+        #                   traceback.print_stack(f, file=sio)
+        #                   sinfo = sio.getvalue()
+        #                   if sinfo[-1] == '\n':
+        #                           sinfo = sinfo[:-1]
+        #                   sio.close()
+        #           rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
+        #           break
+        return rv
+
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
+                                 func=None, extra=None, sinfo=None):
+        """
+        A factory method which can be overridden in subclasses to create
+        specialized LogRecords.
+        """
+        rv = _logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
+                                                     sinfo)
+        if extra is not None:
+            for key in extra:
+                if (key in ["message", "asctime"]) or (key in rv.__dict__):
+                    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
+                rv.__dict__[key] = extra[key]
+        return rv
+
+    def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False):
+        """
+        Low-level logging routine which creates a LogRecord and then calls
+        all the handlers of this logger to handle the record.
+        """
+        sinfo = None
+        if _srcfile:
+            #IronPython doesn't track Python frames, so findCaller raises an
+            #exception on some versions of IronPython. We trap it here so that
+            #IronPython can use logging.
+            try:
+                fn, lno, func, sinfo = self.findCaller(stack_info)
+            except ValueError: # pragma: no cover
+                fn, lno, func = "(unknown file)", 0, "(unknown function)"
+        else: # pragma: no cover
+            fn, lno, func = "(unknown file)", 0, "(unknown function)"
+        # @note - Not sure how we are going to handle this yet
+        #        Need to consider possibly implementing parts of sys
+        # if exc_info:
+        #           if isinstance(exc_info, BaseException):
+        #                   exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+        #           elif not isinstance(exc_info, tuple):
+        #                   exc_info = sys.exc_info()
+        record = self.makeRecord(self.name, level, fn, lno, msg, args,
+                                                         exc_info, func, extra, sinfo)
+        self.handle(record)
+
+    def handle(self, record):
+        """
+        Call the handlers for the specified record.
+
+        This method is used for unpickled records received from a socket, as
+        well as those created locally. Logger-level filtering is applied.
+        """
+        if (not self.disabled) and self.filter(record):
+            self.callHandlers(record)
+
+    def addHandler(self, hdlr):
+        """
+        Add the specified handler to this logger.
+        """
+        _acquireLock()
+        try:
+            if not (hdlr in self.handlers):
+                self.handlers.append(hdlr)
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            _releaseLock()
+
+    def removeHandler(self, hdlr):
+        """
+        Remove the specified handler from this logger.
+        """
+        _acquireLock()
+        try:
+            if hdlr in self.handlers:
+                self.handlers.remove(hdlr)
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            _releaseLock()
+
+    def hasHandlers(self):
+        """
+        See if this logger has any handlers configured.
+
+        Loop through all handlers for this logger and its parents in the
+        logger hierarchy. Return True if a handler was found, else False.
+        Stop searching up the hierarchy whenever a logger with the "propagate"
+        attribute set to zero is found - that will be the last logger which
+        is checked for the existence of handlers.
+        """
+        c = self
+        rv = False
+        while c:
+            if len(c.handlers) > 0:
+                rv = True
+                break
+            if not c.propagate:
+                break
+            else:
+                c = c.parent
+        return rv
+
+    def callHandlers(self, record):
+        """
+        Pass a record to all relevant handlers.
+
+        Loop through all handlers for this logger and its parents in the
+        logger hierarchy. If no handler was found, output a one-off error
+        message to sys.stderr. Stop searching up the hierarchy whenever a
+        logger with the "propagate" attribute set to zero is found - that
+        will be the last logger whose handlers are called.
+        """
+        c = self
+        found = 0
+        while c:
+            for hdlr in c.handlers:
+                found = found + 1
+                if record.levelno >= hdlr.level:
+                    hdlr.handle(record)
+            if not c.propagate:
+                c = None        #break out
+            else:
+                c = c.parent
+        if (found == 0):
+            if lastResort:
+                if record.levelno >= lastResort.level:
+                    lastResort.handle(record)
+            elif raiseExceptions and not self.manager.emittedNoHandlerWarning:
+                _consoleStream.write("No handlers could be found for logger \"{}\"".format(self.name))
+                self.manager.emittedNoHandlerWarning = True
+
+    def getEffectiveLevel(self):
+        """
+        Get the effective level for this logger.
+
+        Loop through this logger and its parents in the logger hierarchy,
+        looking for a non-zero logging level. Return the first one found.
+        """
+        logger = self
+        while logger:
+            if logger.level:
+                return logger.level
+            logger = logger.parent
+        return NOTSET
+
+    def isEnabledFor(self, level):
+        """
+        Is this logger enabled for level 'level'?
+        """
+        if self.manager.disable >= level:
+            return False
+        return level >= self.getEffectiveLevel()
+
+    def getChild(self, suffix):
+        """
+        Get a logger which is a descendant to this one.
+
+        This is a convenience method, such that
+
+        logging.getLogger('abc').getChild('def.ghi')
+
+        is the same as
+
+        logging.getLogger('abc.def.ghi')
+
+        It's useful, for example, when the parent logger is named using
+        __name__ rather than a literal string.
+        """
+        if self.root is not self:
+            suffix = '.'.join((self.name, suffix))
+        return self.manager.getLogger(suffix)
+
+    def __repr__(self):
+        level = getLevelName(self.getEffectiveLevel())
+        return '<{} {} ({})>'.format(self.__class__.__name__, self.name, level)
+
+
+class RootLogger(Logger):
+    """
+    A root logger is not that different to any other logger, except that
+    it must have a logging level and there is only one instance of it in
+    the hierarchy.
+    """
+    def __init__(self, level):
+        """
+        Initialize the logger with the name "root".
+        """
+        Logger.__init__(self, "root", level)
+
+_loggerClass = Logger
+
+class LoggerAdapter(object):
+    """
+    An adapter for loggers which makes it easier to specify contextual
+    information in logging output.
+    """
+
+    def __init__(self, logger, extra):
+        """
+        Initialize the adapter with a logger and a dict-like object which
+        provides contextual information. This constructor signature allows
+        easy stacking of LoggerAdapters, if so desired.
+
+        You can effectively pass keyword arguments as shown in the
+        following example:
+
+        adapter = LoggerAdapter(someLogger, dict(p1=v1, p2="v2"))
+        """
+        self.logger = logger
+        self.extra = extra
+
+    def process(self, msg, kwargs):
+        """
+        Process the logging message and keyword arguments passed in to
+        a logging call to insert contextual information. You can either
+        manipulate the message itself, the keyword args or both. Return
+        the message and kwargs modified (or not) to suit your needs.
+
+        Normally, you'll only need to override this one method in a
+        LoggerAdapter subclass for your specific needs.
+        """
+        kwargs["extra"] = self.extra
+        return msg, kwargs
+
+    __pragma__('kwargs')
+    #
+    # Boilerplate convenience methods
+    #
+    def debug(self, msg, *args, **kwargs):
+        """
+        Delegate a debug call to the underlying logger.
+        """
+        self.log(DEBUG, msg, *args, **kwargs)
+
+    def info(self, msg, *args, **kwargs):
+        """
+        Delegate an info call to the underlying logger.
+        """
+        self.log(INFO, msg, *args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """
+        Delegate a warning call to the underlying logger.
+        """
+        self.log(WARNING, msg, *args, **kwargs)
+
+    def warn(self, msg, *args, **kwargs):
+        # @note - No warnings module yet
+        #warnings.warn("The 'warn' method is deprecated, "
+        #                           "use 'warning' instead", DeprecationWarning, 2)
+        self.warning(msg, *args, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        """
+        Delegate an error call to the underlying logger.
+        """
+        self.log(ERROR, msg, *args, **kwargs)
+
+    def exception(self, msg, *args, exc_info=True, **kwargs):
+        """
+        Delegate an exception call to the underlying logger.
+        """
+        self.log(ERROR, msg, *args, exc_info=exc_info, **kwargs)
+
+    def critical(self, msg, *args, **kwargs):
+        """
+        Delegate a critical call to the underlying logger.
+        """
+        self.log(CRITICAL, msg, *args, **kwargs)
+
+    def log(self, level, msg, *args, **kwargs):
+        """
+        Delegate a log call to the underlying logger, after adding
+        contextual information from this adapter instance.
+        """
+        if self.isEnabledFor(level):
+            msg, kwargs = self.process(msg, kwargs)
+            self.logger._log(level, msg, args, **kwargs)
+    __pragma__('nokwargs')
+
+    def isEnabledFor(self, level):
+        """
+        Is this logger enabled for level 'level'?
+        """
+        if self.logger.manager.disable >= level:
+            return False
+        return level >= self.getEffectiveLevel()
+
+    def setLevel(self, level):
+        """
+        Set the specified level on the underlying logger.
+        """
+        self.logger.setLevel(level)
+
+    def getEffectiveLevel(self):
+        """
+        Get the effective level for the underlying logger.
+        """
+        return self.logger.getEffectiveLevel()
+
+    def hasHandlers(self):
+        """
+        See if the underlying logger has any handlers.
+        """
+        return self.logger.hasHandlers()
+
+    def __repr__(self):
+        logger = self.logger
+        level = getLevelName(logger.getEffectiveLevel())
+        return '<{} {} ({})>'.format(self.__class__.__name__, logger.name, level)
+
+root = RootLogger(WARNING)
+Logger.root = root
+Logger.manager = Manager(Logger.root)
+# @note - this is necessary because I think there may be a bug
+# in the way that class level attributes are distributed to
+# instances of a class
+root.manager = Logger.manager
+
+#---------------------------------------------------------------------------
+# Configuration classes and functions
+#---------------------------------------------------------------------------
+__pragma__('kwargs')
+def basicConfig(**kwargs):
+    """
+    Do basic configuration for the logging system.
+
+    This function does nothing if the root logger already has handlers
+    configured. It is a convenience method intended for use by simple scripts
+    to do one-shot configuration of the logging package.
+
+    The default behaviour is to create a StreamHandler which writes to
+    console.log, set a formatter using the BASIC_FORMAT format string, and
+    add the handler to the root logger.
+
+    A number of optional keyword arguments may be specified, which can alter
+    the default behaviour.
+
+    format      Use the specified format string for the handler.
+    datefmt     Use the specified date/time format.
+    style           If a format string is specified, use this to specify the
+                            type of format string (possible values '%', '{', '$', for
+                            %-formatting, :meth:`str.format` and :class:`string.Template`
+                            - defaults to '%').
+    level           Set the root logger level to the specified level.
+    stream      Use the specified stream to initialize the StreamHandler. Note
+                            that this argument is incompatible with 'filename' - if both
+                            are present, 'stream' is ignored.
+    handlers    If specified, this should be an iterable of already created
+                            handlers, which will be added to the root handler. Any handler
+                            in the list which does not have a formatter assigned will be
+                            assigned the formatter created in this function.
+
+    .. versionchanged:: 3.2
+    Added the ``style`` parameter.
+
+    .. versionchanged:: 3.3
+    Added the ``handlers`` parameter. A ``ValueError`` is now thrown for
+    incompatible arguments (e.g. ``handlers`` specified together with
+    ``filename``/``filemode``, or ``filename``/``filemode`` specified
+    together with ``stream``, or ``handlers`` specified together with
+    ``stream``.
+    """
+    # Add thread safety in case someone mistakenly calls
+    # basicConfig() from multiple threads
+    _acquireLock()
+    try:
+        if len(root.handlers) == 0:
+            handlers = kwargs["handlers"]
+            # @note - kwargs as the function args does not seem to
+            #     be a full-fledged dict
+            #handlers = kwargs.pop("handlers", None)
+            if handlers is not None:
+                if "stream" in kwargs:
+                    raise ValueError("'stream' should not be "
+                                                     "specified together with 'handlers'")
+            if handlers is None:
+                stream = kwargs["stream"]
+                #stream = kwargs.pop("stream", None)
+                h = StreamHandler(stream)
+                handlers = [h]
+            dfs = kwargs["datefmt"]
+            #dfs = kwargs.pop("datefmt", None)
+            style = kwargs["style"]
+            if ( style is None ):
+                style = "{"
+            #style = kwargs.pop("style", '{')
+            if style not in _STYLES:
+                raise ValueError('Style must be one of: {}'.format(','.join(_STYLES.keys())))
+            fs = kwargs["format"]
+            if ( fs is None ):
+                fs = _STYLES[style][1]
+            #fs = kwargs.pop("format", _STYLES[style][1])
+            fmt = Formatter(fs, dfs, style)
+            for h in handlers:
+                if h.formatter is None:
+                    h.setFormatter(fmt)
+                root.addHandler(h)
+            level = kwargs["level"]
+            #level = kwargs.pop("level", None)
+            if level is not None:
+                root.setLevel(level)
+            # @todo - currently we don't have a full dict object
+            # in kwargs - so we have to make sacrifices.
+            #if kwargs:
+            #    keys = ', '.join(kwargs.keys())
+            #    raise ValueError('Unrecognised argument(s): {}'.format(keys))
+    except Exception as exc: # @note - this is a hack around bug in transcrypt
+        raise exc
+
+    finally:
+        _releaseLock()
+
+__pragma__('nokwargs')
+
+#---------------------------------------------------------------------------
+# Utility functions at module level.
+# Basically delegate everything to the root logger.
+#---------------------------------------------------------------------------
+
+def getLogger(name=None):
+    """
+    Return a logger with the specified name, creating it if necessary.
+
+    If no name is specified, return the root logger.
+    """
+    if name:
+        return Logger.manager.getLogger(name)
+    else:
+        return root
+
+__pragma__('kwargs')
+def critical(msg, *args, **kwargs):
+    """
+    Log a message with severity 'CRITICAL' on the root logger. If the logger
+    has no handlers, call basicConfig() to add a console handler with a
+    pre-defined format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.critical(msg, *args, **kwargs)
+
+fatal = critical
+
+def error(msg, *args, **kwargs):
+    """
+    Log a message with severity 'ERROR' on the root logger. If the logger has
+    no handlers, call basicConfig() to add a console handler with a pre-defined
+    format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.error(msg, *args, **kwargs)
+
+def exception(msg, *args, exc_info=True, **kwargs):
+    """
+    Log a message with severity 'ERROR' on the root logger, with exception
+    information. If the logger has no handlers, basicConfig() is called to add
+    a console handler with a pre-defined format.
+    """
+    error(msg, *args, exc_info=exc_info, **kwargs)
+
+def warning(msg, *args, **kwargs):
+    """
+    Log a message with severity 'WARNING' on the root logger. If the logger has
+    no handlers, call basicConfig() to add a console handler with a pre-defined
+    format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.warning(msg, *args, **kwargs)
+
+def warn(msg, *args, **kwargs):
+    # @note warnings not implemeneted yet.
+    #warnings.warn("The 'warn' function is deprecated, "
+    #                           "use 'warning' instead", DeprecationWarning, 2)
+    warning(msg, *args, **kwargs)
+
+def info(msg, *args, **kwargs):
+    """
+    Log a message with severity 'INFO' on the root logger. If the logger has
+    no handlers, call basicConfig() to add a console handler with a pre-defined
+    format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.info(msg, *args, **kwargs)
+
+def debug(msg, *args, **kwargs):
+    """
+    Log a message with severity 'DEBUG' on the root logger. If the logger has
+    no handlers, call basicConfig() to add a console handler with a pre-defined
+    format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.debug(msg, *args, **kwargs)
+
+def log(level, msg, *args, **kwargs):
+    """
+    Log 'msg.format(args)' with the integer severity 'level' on the root logger. If
+    the logger has no handlers, call basicConfig() to add a console handler
+    with a pre-defined format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.log(level, msg, *args, **kwargs)
+__pragma__('nokwargs')
+
+def disable(level):
+    """
+    Disable all logging calls of severity 'level' and below.
+    """
+    root.manager.disable = level
+
+def shutdown(handlerList=_handlerList):
+    """
+    Perform any cleanup actions in the logging system (e.g. flushing
+    buffers).
+
+    Should be called at application exit.
+    """
+    for wr in reversed(handlerList[:]):
+        #errors might occur, for example, if files are locked
+        #we just ignore them if raiseExceptions is not set
+        try:
+            h = wr()
+            if h:
+                try:
+                    h.acquire()
+                    h.flush()
+                    h.close()
+                except (OSError, ValueError):
+                    # Ignore errors which might be caused
+                    # because handlers have been closed but
+                    # references to them are still around at
+                    # application exit.
+                    pass
+                finally:
+                    h.release()
+        except Exception as exc: # ignore everything, as we're shutting down
+            if raiseExceptions:
+                raise exc
+            #else, swallow
+
+#Let's try and shutdown automatically on application exit...
+# @note - this is not implemented yet - not sure it
+#       event makes sense for this application
+#import atexit
+#atexit.register(shutdown)
+
+# Null handler
+
+class NullHandler(Handler):
+    """
+    This handler does nothing. It's intended to be used to avoid the
+    "No handlers could be found for logger XXX" one-off warning. This is
+    important for library code, which may contain code to log events. If a user
+    of the library does not configure logging, the one-off warning might be
+    produced; to avoid this, the library developer simply needs to instantiate
+    a NullHandler and add it to the top-level logger of the library module or
+    package.
+        """
+    def handle(self, record):
+        """Stub."""
+
+    def emit(self, record):
+        """Stub."""
+
+    def createLock(self):
+        self.lock = None
+
+# Warnings integration
+
+_warnings_showwarning = None
+
+def _showwarning(message, category, filename, lineno, file=None, line=None):
+    """
+    Implementation of showwarnings which redirects to logging, which will first
+    check to see if the file parameter is None. If a file is specified, it will
+    delegate to the original warnings implementation of showwarning. Otherwise,
+    it will call warnings.formatwarning and will log the resulting string to a
+    warnings logger named "py.warnings" with level logging.WARNING.
+    """
+    if file is not None:
+        if _warnings_showwarning is not None:
+            _warnings_showwarning(message, category, filename, lineno, file, line)
+    else:
+        # @note - no warnings module
+        #s = warnings.formatwarning(message, category, filename, lineno, line)
+        s = "WARNING: {}, {}, {}, {}, {}".format(message, category, filename, lineno, line)
+        logger = getLogger("py.warnings")
+        if not logger.handlers:
+            logger.addHandler(NullHandler())
+        logger.warning(s)
+
+def captureWarnings(capture):
+    """
+    If capture is true, redirect all warnings to the logging package.
+    If capture is False, ensure that warnings are not redirected to logging
+    but to their original destinations.
+    """
+    _consoleStream.write("Warnings not Handled By Logging")
+    # global _warnings_showwarning
+    # if capture:
+    #           if _warnings_showwarning is None:
+    #                   _warnings_showwarning = warnings.showwarning
+    #                   warnings.showwarning = _showwarning
+    # else:
+    #           if _warnings_showwarning is not None:
+    #                   warnings.showwarning = _warnings_showwarning
+    #                   _warnings_showwarning = None

--- a/transcrypt/modules/logging/config.py
+++ b/transcrypt/modules/logging/config.py
@@ -1,0 +1,802 @@
+# Copyright 2001-2016 by Vinay Sajip. All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright notice appear in all copies and that
+# both that copyright notice and this permission notice appear in
+# supporting documentation, and that the name of Vinay Sajip
+# not be used in advertising or publicity pertaining to distribution
+# of the software without specific, written prior permission.
+# VINAY SAJIP DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL
+# VINAY SAJIP BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
+# ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+# IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Configuration functions for the logging package for Python. The core package
+is based on PEP 282 and comments thereto in comp.lang.python, and influenced
+by Apache's log4j system.
+
+Copyright (C) 2001-2016 Vinay Sajip. All Rights Reserved.
+
+To use, simply 'import logging' and log away!
+
+Edited by Carl Allendorph 2016 for Transcrypt.
+
+Transcrypt Limitations:
+
+This code makes heavy use of the import functionality of the
+CPython implementation to provide loading of formatters, handlers,
+etc. This is fundementally counter to what transcrypt is setup
+to do. As such, where a resolve method may have been used previously,
+the user has the option to either use the default classes from the
+`logging` module, like logging.Formatter, or can pass in their own
+calleable that can be used to generate the necessary objects.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+This code is not well tested yet!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+"""
+
+import logging
+import logging.handlers
+import re
+
+# No Threads
+# try:
+#           import _thread as thread
+#           import threading
+# except ImportError: #pragma: no cover
+#           thread = None
+thread = None
+
+#from socketserver import ThreadingTCPServer, StreamRequestHandler
+
+
+DEFAULT_LOGGING_CONFIG_PORT = 9030
+
+RESET_ERROR = 1 #errno.ECONNRESET
+
+#
+#       The following code implements a socket listener for on-the-fly
+#       reconfiguration of logging.
+#
+#       _listener holds the server object doing the listening
+_listener = None
+
+def fileConfig(fname, defaults=None, disable_existing_loggers=True):
+    """ File IO not implemented
+    """
+    raise NotImplementedError("No Filesystem to read file config from")
+
+
+def _resolve(name):
+    """Resolve a dotted name to a global object."""
+    # @note - transcrypt does not have import so we can not
+    # implement resolve via __import__
+    raise NotImplementedError("No __import__ Available")
+    # name = name.split('.')
+    # used = name.pop(0)
+    # found = __import__(used)
+    # for n in name:
+    #   used = used + '.' + n
+    #   try:
+    #       found = getattr(found, n)
+    #   except AttributeError:
+    #       __import__(used)
+    #       found = getattr(found, n)
+    # return found
+
+def _strip_spaces(alist):
+    return map(lambda x: x.strip(), alist)
+
+def _create_formatters(cp):
+    """Create and return formatters"""
+    flist = cp["formatters"]["keys"]
+    if not len(flist):
+        return {}
+    flist = flist.split(",")
+    flist = _strip_spaces(flist)
+    formatters = {}
+    for form in flist:
+        sectname = "formatter_{}".format(form)
+        fs = cp.get(sectname, "format", raw=True, fallback=None)
+        dfs = cp.get(sectname, "datefmt", raw=True, fallback=None)
+        stl = cp.get(sectname, "style", raw=True, fallback='{')
+        c = logging.Formatter
+        class_name = cp[sectname].get("class")
+        if class_name:
+            c = _resolve(class_name)
+        f = c(fs, dfs, stl)
+        formatters[form] = f
+    return formatters
+
+
+def _install_handlers(cp, formatters):
+    """Install and return handlers"""
+    hlist = cp["handlers"]["keys"]
+    if not len(hlist):
+        return {}
+    hlist = hlist.split(",")
+    hlist = _strip_spaces(hlist)
+    handlers = {}
+    fixups = [] #for inter-handler references
+    for hand in hlist:
+        section = cp["handler_{}".format(hand)]
+        klass = section["class"]
+        fmt = section.get("formatter", "")
+        try:
+            klass = eval(klass, vars(logging))
+        except (AttributeError, NameError):
+            klass = _resolve(klass)
+        args = section["args"]
+        args = eval(args, vars(logging))
+        h = klass(*args)
+        if "level" in section:
+            level = section["level"]
+            h.setLevel(level)
+        if len(fmt):
+            h.setFormatter(formatters[fmt])
+        if issubclass(klass, logging.handlers.MemoryHandler):
+            target = section.get("target", "")
+            if len(target): #the target handler may not be loaded yet, so keep for later...
+                fixups.append((h, target))
+        handlers[hand] = h
+    #now all handlers are loaded, fixup inter-handler references...
+    for h, t in fixups:
+        h.setTarget(handlers[t])
+    return handlers
+
+def _handle_existing_loggers(existing, child_loggers, disable_existing):
+    """
+    When (re)configuring logging, handle loggers which were in the previous
+    configuration but are not in the new configuration. There's no point
+    deleting them as other threads may continue to hold references to them;
+    and by disabling them, you stop them doing any logging.
+
+    However, don't disable children of named loggers, as that's probably not
+    what was intended by the user. Also, allow existing loggers to NOT be
+    disabled if disable_existing is false.
+    """
+    root = logging.root
+    for log in existing:
+        logger = root.manager.loggerDict[log]
+        if log in child_loggers:
+            logger.level = logging.NOTSET
+            logger.handlers = []
+            logger.propagate = True
+        else:
+            logger.disabled = disable_existing
+
+def _install_loggers(cp, handlers, disable_existing):
+    """Create and install loggers"""
+
+    # configure the root first
+    llist = cp["loggers"]["keys"]
+    llist = llist.split(",")
+    llist = list(map(lambda x: x.strip(), llist))
+    llist.remove("root")
+    section = cp["logger_root"]
+    root = logging.root
+    log = root
+    if "level" in section:
+        level = section["level"]
+        log.setLevel(level)
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    hlist = section["handlers"]
+    if len(hlist):
+        hlist = hlist.split(",")
+        hlist = _strip_spaces(hlist)
+        for hand in hlist:
+            log.addHandler(handlers[hand])
+
+    #and now the others...
+    #we don't want to lose the existing loggers,
+    #since other threads may have pointers to them.
+    #existing is set to contain all existing loggers,
+    #and as we go through the new configuration we
+    #remove any which are configured. At the end,
+    #what's left in existing is the set of loggers
+    #which were in the previous configuration but
+    #which are not in the new configuration.
+    existing = list(root.manager.loggerDict.keys())
+    #The list needs to be sorted so that we can
+    #avoid disabling child loggers of explicitly
+    #named loggers. With a sorted list it is easier
+    #to find the child loggers.
+    existing.sort()
+    #We'll keep the list of existing loggers
+    #which are children of named loggers here...
+    child_loggers = []
+    #now set up the new ones...
+    for log in llist:
+        section = cp["logger_{}".format(log)]
+        qn = section["qualname"]
+        propagate = section.getint("propagate", fallback=1)
+        logger = logging.getLogger(qn)
+        if qn in existing:
+            i = existing.index(qn) + 1 # start with the entry after qn
+            prefixed = qn + "."
+            pflen = len(prefixed)
+            num_existing = len(existing)
+            while i < num_existing:
+                if existing[i][:pflen] == prefixed:
+                    child_loggers.append(existing[i])
+                i += 1
+            existing.remove(qn)
+        if "level" in section:
+            level = section["level"]
+            logger.setLevel(level)
+        for h in logger.handlers[:]:
+            logger.removeHandler(h)
+        logger.propagate = propagate
+        logger.disabled = 0
+        hlist = section["handlers"]
+        if len(hlist):
+            hlist = hlist.split(",")
+            hlist = _strip_spaces(hlist)
+            for hand in hlist:
+                logger.addHandler(handlers[hand])
+
+    #Disable any old loggers. There's no point deleting
+    #them as other threads may continue to hold references
+    #and by disabling them, you stop them doing any logging.
+    #However, don't disable children of named loggers, as that's
+    #probably not what was intended by the user.
+    #for log in existing:
+    #        logger = root.manager.loggerDict[log]
+    #        if log in child_loggers:
+    #                logger.level = logging.NOTSET
+    #                logger.handlers = []
+    #                logger.propagate = 1
+    #        elif disable_existing_loggers:
+    #                logger.disabled = 1
+    _handle_existing_loggers(existing, child_loggers, disable_existing)
+
+IDENTIFIER = re.compile('^[a-z_][a-z0-9_]*$', re.I)
+
+
+def valid_ident(s):
+    m = IDENTIFIER.match(s)
+    if not m:
+        raise ValueError('Not a valid Python identifier: {}'.format(str(s)))
+    return True
+
+
+class ConvertingMixin(object):
+    """For ConvertingXXX's, this mixin class provides common functions"""
+
+    def convert_with_key(self, key, value, replace=True):
+        result = self.configurator.convert(value)
+        #If the converted value is different, save for next time
+        if value is not result:
+            if replace:
+                self[key] = result
+            if type(result) in (ConvertingDict, ConvertingList,
+                                                    ConvertingTuple):
+                result.parent = self
+                result.key = key
+        return result
+
+    def convert(self, value):
+        result = self.configurator.convert(value)
+        if value is not result:
+            if type(result) in (ConvertingDict, ConvertingList,
+                                                    ConvertingTuple):
+                result.parent = self
+        return result
+
+
+# The ConvertingXXX classes are wrappers around standard Python containers,
+# and they serve to convert any suitable values in the container. The
+# conversion converts base dicts, lists and tuples to their wrapped
+# equivalents, whereas strings which match a conversion format are converted
+# appropriately.
+#
+# Each wrapper should have a configurator attribute holding the actual
+# configurator to use for conversion.
+
+class ConvertingDict(dict, ConvertingMixin):
+    """A converting dictionary wrapper."""
+
+    def __getitem__(self, key):
+        value = dict.__getitem__(self, key)
+        return self.convert_with_key(key, value)
+
+    def get(self, key, default=None):
+        value = dict.get(self, key, default)
+        return self.convert_with_key(key, value)
+
+    def pop(self, key, default=None):
+        value = dict.pop(self, key, default)
+        return self.convert_with_key(key, value, replace=False)
+
+class ConvertingList(list, ConvertingMixin):
+    """A converting list wrapper."""
+    def __getitem__(self, key):
+        value = list.__getitem__(self, key)
+        return self.convert_with_key(key, value)
+
+    def pop(self, idx=-1):
+        value = list.pop(self, idx)
+        return self.convert(value)
+
+class ConvertingTuple(tuple, ConvertingMixin):
+    """A converting tuple wrapper."""
+    def __getitem__(self, key):
+        value = tuple.__getitem__(self, key)
+        # Can't replace a tuple entry.
+        return self.convert_with_key(key, value, replace=False)
+
+class BaseConfigurator(object):
+    """
+    The configurator base class which defines some useful defaults.
+    """
+
+    #CONVERT_PATTERN = re.compile(r'^(?P<prefix>[a-z]+)://(?P<suffix>.*)$')
+    # Simplified grouping to make it easier to use the
+    # javscript regex engine if necessary
+    CONVERT_PATTERN = re.compile(r'^([a-z]+)://(.*)$')
+
+    WORD_PATTERN = re.compile(r'^\s*(\w+)\s*')
+    DOT_PATTERN = re.compile(r'^\.\s*(\w+)\s*')
+    INDEX_PATTERN = re.compile(r'^\[\s*(\w+)\s*\]\s*')
+    DIGIT_PATTERN = re.compile(r'^\d+$')
+
+    value_converters = {
+        'ext' : 'ext_convert',
+        'cfg' : 'cfg_convert',
+    }
+
+    # We might want to use a different one, e.g. importlib
+    # @note - import is not going to work here because we don't
+    #    have this construct in transcrypt
+    #importer = staticmethod(__import__)
+    importer = None
+
+    def __init__(self, config):
+        self.config = ConvertingDict(config)
+        self.config.configurator = self
+
+    def resolve(self, s):
+        """
+        Resolve strings to objects using standard import and attribute
+        syntax.
+        """
+        raise NotImplementedError("Transcrypt lacks import")
+        # name = s.split('.')
+        # used = name.pop(0)
+        # try:
+        #   found = self.importer(used)
+        #   for frag in name:
+        #       used += '.' + frag
+        #       try:
+        #           found = getattr(found, frag)
+        #       except AttributeError:
+        #           self.importer(used)
+        #           found = getattr(found, frag)
+        #   return found
+        # except ImportError:
+        #   e, tb = sys.exc_info()[1:]
+        #   v = ValueError('Cannot resolve {}: {}'.format(str(s), e))
+        #   v.__cause__, v.__traceback__ = e, tb
+        #   raise v
+
+    def ext_convert(self, value):
+        """Default converter for the ext:// protocol."""
+        return self.resolve(value)
+
+    def cfg_convert(self, value):
+        """Default converter for the cfg:// protocol."""
+        rest = value
+        m = self.WORD_PATTERN.match(rest)
+        if m is None:
+            raise ValueError("Unable to convert {}".format(value))
+        else:
+            rest = rest[m.end():]
+            d = self.config[m.groups()[0]]
+            #print d, rest
+            while rest:
+                m = self.DOT_PATTERN.match(rest)
+                if m:
+                    d = d[m.groups()[0]]
+                else:
+                    m = self.INDEX_PATTERN.match(rest)
+                    if m:
+                        idx = m.groups()[0]
+                        if not self.DIGIT_PATTERN.match(idx):
+                            d = d[idx]
+                        else:
+                            try:
+                                n = int(idx) # try as number first (most likely)
+                                d = d[n]
+                            except TypeError:
+                                d = d[idx]
+                if m:
+                    rest = rest[m.end():]
+                else:
+                    raise ValueError('Unable to convert '
+                                                     '{} at {}'.format(str(value), str(rest)))
+                #rest should be empty
+        return d
+
+    def convert(self, value):
+        """
+        Convert values to an appropriate type. dicts, lists and tuples are
+        replaced by their converting alternatives. Strings are checked to
+        see if they have a conversion format and are converted if they do.
+        """
+        if not isinstance(value, ConvertingDict) and isinstance(value, dict):
+            value = ConvertingDict(value)
+            value.configurator = self
+        elif not isinstance(value, ConvertingList) and isinstance(value, list):
+            value = ConvertingList(value)
+            value.configurator = self
+        elif not isinstance(value, ConvertingTuple) and\
+                 isinstance(value, tuple):
+            value = ConvertingTuple(value)
+            value.configurator = self
+        elif isinstance(value, str): # str for py3k
+            m = self.CONVERT_PATTERN.match(value)
+            if m:
+                d = m.groupdict()
+                prefix = d[1] # prefix
+                converter = self.value_converters.get(prefix, None)
+                if converter:
+                    suffix = d[2] # suffix
+                    converter = getattr(self, converter)
+                    value = converter(suffix)
+        return value
+
+    def configure_custom(self, config):
+        """Configure an object with a user-supplied factory."""
+        c = config.pop('()')
+        if not callable(c):
+            c = self.resolve(c)
+        props = config.pop('.', None)
+        # Check for valid identifiers
+        kwargs = dict([(k, config[k]) for k in config if valid_ident(k)])
+        result = c(**kwargs)
+        if props:
+            for name, value in props.items():
+                setattr(result, name, value)
+        return result
+
+    def as_tuple(self, value):
+        """Utility function which converts lists to tuples."""
+        if isinstance(value, list):
+            value = tuple(value)
+        return value
+
+class DictConfigurator(BaseConfigurator):
+    """
+    Configure logging using a dictionary-like object to describe the
+    configuration.
+    """
+
+    def configure(self):
+        """Do the configuration."""
+
+        config = self.config
+        if 'version' not in config:
+            raise ValueError("dictionary doesn't specify a version")
+        if config['version'] != 1:
+            raise ValueError("Unsupported version: {}".format(config['version']))
+        incremental = config.pop('incremental', False)
+        EMPTY_DICT = {}
+        logging._acquireLock()
+        try:
+            if incremental:
+                handlers = config.get('handlers', EMPTY_DICT)
+                for name in handlers:
+                    if name not in logging._handlers:
+                        raise ValueError('No handler found with '
+                                                                                 'name {}'.format(name))
+                    else:
+                        try:
+                            handler = logging._handlers[name]
+                            handler_config = handlers[name]
+                            level = handler_config.get('level', None)
+                            if level:
+                                handler.setLevel(logging._checkLevel(level))
+                        except Exception as e:
+                            raise ValueError('Unable to configure handler '
+                                                             '{}'.format(name)) from e
+                loggers = config.get('loggers', EMPTY_DICT)
+                for name in loggers:
+                    try:
+                        self.configure_logger(name, loggers[name], True)
+                    except Exception as e:
+                        raise ValueError('Unable to configure logger {}'.format(name)) from e
+                root = config.get('root', None)
+                if root:
+                    try:
+                        self.configure_root(root, True)
+                    except Exception as e:
+                        raise ValueError('Unable to configure root logger') from e
+            else:
+                disable_existing = config.pop('disable_existing_loggers', True)
+
+                logging._handlers.clear()
+                del logging._handlerList[:]
+
+                # Do formatters first - they don't refer to anything else
+                formatters = config.get('formatters', EMPTY_DICT)
+                for name in formatters:
+                    try:
+                        formatters[name] = self.configure_formatter(formatters[name])
+                    except Exception as e:
+                        raise ValueError('Unable to configure formatter {}'.format(name)) from e
+                # Next, do filters - they don't refer to anything else, either
+                filters = config.get('filters', EMPTY_DICT)
+                for name in filters:
+                    try:
+                        filters[name] = self.configure_filter(filters[name])
+                    except Exception as e:
+                        raise ValueError('Unable to configure filter {}'.format(name)) from e
+
+                # Next, do handlers - they refer to formatters and filters
+                # As handlers can refer to other handlers, sort the keys
+                # to allow a deterministic order of configuration
+                handlers = config.get('handlers', EMPTY_DICT)
+                deferred = []
+                for name in sorted(handlers):
+                    try:
+                        handler = self.configure_handler(handlers[name])
+                        handler.name = name
+                        handlers[name] = handler
+                    except Exception as e:
+                        if 'target not configured yet' in str(e.__cause__):
+                            deferred.append(name)
+                        else:
+                            raise ValueError(
+                            'Unable to config handler {}'.format(name)
+                            ) from e
+
+                # Now do any that were deferred
+                for name in deferred:
+                    try:
+                        handler = self.configure_handler(handlers[name])
+                        handler.name = name
+                        handlers[name] = handler
+                    except Exception as e:
+                        raise ValueError(
+                            'Unable to configure handler {}'.format(name)
+                        ) from e
+
+                # Next, do loggers - they refer to handlers and filters
+
+                #we don't want to lose the existing loggers,
+                #since other threads may have pointers to them.
+                #existing is set to contain all existing loggers,
+                #and as we go through the new configuration we
+                #remove any which are configured. At the end,
+                #what's left in existing is the set of loggers
+                #which were in the previous configuration but
+                #which are not in the new configuration.
+                root = logging.root
+                existing = list(root.manager.loggerDict.keys())
+                #The list needs to be sorted so that we can
+                #avoid disabling child loggers of explicitly
+                #named loggers. With a sorted list it is easier
+                #to find the child loggers.
+                existing.sort()
+                #We'll keep the list of existing loggers
+                #which are children of named loggers here...
+                child_loggers = []
+                #now set up the new ones...
+                loggers = config.get('loggers', EMPTY_DICT)
+                for name in loggers:
+                    if name in existing:
+                        i = existing.index(name) + 1 # look after name
+                        prefixed = name + "."
+                        pflen = len(prefixed)
+                        num_existing = len(existing)
+                        while i < num_existing:
+                            if existing[i][:pflen] == prefixed:
+                                child_loggers.append(existing[i])
+                            i += 1
+                        existing.remove(name)
+                    try:
+                        self.configure_logger(name, loggers[name])
+                    except Exception as e:
+                        raise ValueError(
+                            'Unable to configure logger {}'.format(name)
+                        )from e
+
+                #Disable any old loggers. There's no point deleting
+                #them as other threads may continue to hold references
+                #and by disabling them, you stop them doing any logging.
+                #However, don't disable children of named loggers, as that's
+                #probably not what was intended by the user.
+                #for log in existing:
+                #        logger = root.manager.loggerDict[log]
+                #        if log in child_loggers:
+                #                logger.level = logging.NOTSET
+                #                logger.handlers = []
+                #                logger.propagate = True
+                #        elif disable_existing:
+                #                logger.disabled = True
+                _handle_existing_loggers(existing, child_loggers,
+                                                                 disable_existing)
+
+                # And finally, do the root logger
+                root = config.get('root', None)
+                if root:
+                    try:
+                        self.configure_root(root)
+                    except Exception as e:
+                        raise ValueError('Unable to configure root '
+                                                         'logger') from e
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            logging._releaseLock()
+
+    def configure_formatter(self, config):
+        """Configure a formatter from a dictionary."""
+        if '()' in config:
+            factory = config['()'] # for use in exception handler
+            try:
+                result = self.configure_custom(config)
+            except TypeError as te:
+                if "'format'" not in str(te):
+                    raise
+                #Name of parameter changed from fmt to format.
+                #Retry with old name.
+                #This is so that code can be used with older Python versions
+                #(e.g. by Django)
+                config['fmt'] = config.pop('format')
+                config['()'] = factory
+                result = self.configure_custom(config)
+        else:
+            fmt = config.get('format', None)
+            dfmt = config.get('datefmt', None)
+            style = config.get('style', '{')
+            cname = config.get('class', None)
+            if not cname:
+                c = logging.Formatter
+            else:
+                c = _resolve(cname)
+            result = c(fmt, dfmt, style)
+        return result
+
+    def configure_filter(self, config):
+        """Configure a filter from a dictionary."""
+        if '()' in config:
+            result = self.configure_custom(config)
+        else:
+            name = config.get('name', '')
+            result = logging.Filter(name)
+        return result
+
+    def add_filters(self, filterer, filters):
+        """Add filters to a filterer from a list of names."""
+        for f in filters:
+            try:
+                filterer.addFilter(self.config['filters'][f])
+            except Exception as e:
+                raise ValueError('Unable to add filter {}'.format(str(f))) from e
+
+    def configure_handler(self, config):
+        """Configure a handler from a dictionary."""
+        config_copy = dict(config)  # for restoring in case of error
+        formatter = config.pop('formatter', None)
+        if formatter:
+            try:
+                formatter = self.config['formatters'][formatter]
+            except Exception as e:
+                raise ValueError('Unable to set formatter {}'.format(str(formatter))) from e
+        level = config.pop('level', None)
+        filters = config.pop('filters', None)
+        if '()' in config:
+            c = config.pop('()')
+            if not callable(c):
+                c = self.resolve(c)
+            factory = c
+        else:
+            cname = config.pop('class')
+            klass = self.resolve(cname)
+            #Special case for handler which refers to another handler
+            if issubclass(klass, logging.handlers.MemoryHandler) and ('target' in config):
+                try:
+                    th = self.config['handlers'][config['target']]
+                    if not isinstance(th, logging.Handler):
+                        config.update(config_copy)  # restore for deferred cfg
+                        raise TypeError('target not configured yet')
+                    config['target'] = th
+                except Exception as e:
+                    raise ValueError('Unable to set target handler {}'.format(config['target'])) from e
+            elif issubclass(klass, logging.handlers.SMTPHandler) and ('mailhost' in config):
+                config['mailhost'] = self.as_tuple(config['mailhost'])
+            elif issubclass(klass, logging.handlers.SysLogHandler) and ('address' in config):
+                config['address'] = self.as_tuple(config['address'])
+            factory = klass
+        props = config.pop('.', None)
+        kwargs = dict([(k, config[k]) for k in config if valid_ident(k)])
+        try:
+            result = factory(**kwargs)
+        except TypeError as te:
+            if "'stream'" not in str(te):
+                raise
+            #The argument name changed from strm to stream
+            #Retry with old name.
+            #This is so that code can be used with older Python versions
+            #(e.g. by Django)
+            kwargs['strm'] = kwargs.pop('stream')
+            result = factory(**kwargs)
+        if formatter:
+            result.setFormatter(formatter)
+        if level is not None:
+            result.setLevel(logging._checkLevel(level))
+        if filters:
+            self.add_filters(result, filters)
+        if props:
+            for name, value in props.items():
+                setattr(result, name, value)
+        return result
+
+    def add_handlers(self, logger, handlers):
+        """Add handlers to a logger from a list of names."""
+        for h in handlers:
+            try:
+                logger.addHandler(self.config['handlers'][h])
+            except Exception as e:
+                raise ValueError('Unable to add handler {}'.format(str(h))) from e
+
+    def common_logger_config(self, logger, config, incremental=False):
+        """
+        Perform configuration which is common to root and non-root loggers.
+        """
+        level = config.get('level', None)
+        if level is not None:
+            logger.setLevel(logging._checkLevel(level))
+        if not incremental:
+            #Remove any existing handlers
+            for h in logger.handlers[:]:
+                logger.removeHandler(h)
+            handlers = config.get('handlers', None)
+            if handlers:
+                self.add_handlers(logger, handlers)
+            filters = config.get('filters', None)
+            if filters:
+                self.add_filters(logger, filters)
+
+    def configure_logger(self, name, config, incremental=False):
+        """Configure a non-root logger from a dictionary."""
+        logger = logging.getLogger(name)
+        self.common_logger_config(logger, config, incremental)
+        propagate = config.get('propagate', None)
+        if propagate is not None:
+            logger.propagate = propagate
+
+    def configure_root(self, config, incremental=False):
+        """Configure a root logger from a dictionary."""
+        root = logging.getLogger()
+        self.common_logger_config(root, config, incremental)
+
+dictConfigClass = DictConfigurator
+
+def dictConfig(config):
+    """Configure logging using a dictionary."""
+    dictConfigClass(config).configure()
+
+
+def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
+    """ Socket server based logging configuration is not enabled
+    """
+    #if not thread: #pragma: no cover
+    #   raise NotImplementedError("listen() needs threading to work")
+    raise NotImplementedError()
+
+
+def stopListening():
+    """
+    Stop the listening server which was created with a call to listen().
+    """
+    pass

--- a/transcrypt/modules/logging/handlers.py
+++ b/transcrypt/modules/logging/handlers.py
@@ -1,0 +1,352 @@
+# Copyright 2001-2016 by Vinay Sajip. All Rights Reserved.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright notice appear in all copies and that
+# both that copyright notice and this permission notice appear in
+# supporting documentation, and that the name of Vinay Sajip
+# not be used in advertising or publicity pertaining to distribution
+# of the software without specific, written prior permission.
+# VINAY SAJIP DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
+# ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL
+# VINAY SAJIP BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR
+# ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+# IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Additional handlers for the logging package for Python. The core package is
+based on PEP 282 and comments thereto in comp.lang.python.
+
+Copyright (C) 2001-2016 Vinay Sajip. All Rights Reserved.
+
+To use, simply 'import logging.handlers' and log away!
+
+Edited by Carl Allendorph 2016 for the Transcrypt project
+
+I've kept some of the handlers but I've pruned anything related to
+the file system at this point. There is a stub in preparation for
+an AJAX based handler that will likely need to be coupled with
+a QueueHandler and maybe a buffered handler.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+This code is not well tested yet!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+"""
+
+from org.transcrypt.stubs.browser import __pragma__
+import logging
+#import time, re
+
+#from stat import ST_DEV, ST_INO, ST_MTIME
+#import queue
+# try:
+#           import threading
+# except ImportError: #pragma: no cover
+#           threading = None
+
+threading = None
+
+#
+# Some constants...
+#
+
+DEFAULT_TCP_LOGGING_PORT        = 9020
+DEFAULT_UDP_LOGGING_PORT        = 9021
+DEFAULT_HTTP_LOGGING_PORT       = 9022
+DEFAULT_SOAP_LOGGING_PORT       = 9023
+SYSLOG_UDP_PORT                         = 514
+SYSLOG_TCP_PORT                         = 514
+
+_MIDNIGHT = 24 * 60 * 60    # number of seconds in a day
+
+
+class AJAXHandler(logging.Handler):
+    """
+    This class provides a means of pushing log records to a webserver
+    via AJAX requests to a host server. Likely will have cross-domain
+    restrictions unless you do something special.
+    """
+    def __init__(self, url, method="GET", headers = []):
+        """
+        Initialize the instance with url and the method type
+        ("GET" or "POST")
+        @param url the page to send the messages to. Generally
+          this is going to be address relative to this host
+          but could also be fullyqualified
+        @param method "GET" or "POST"
+        @param headers list of tuples that contains the
+          headers that will be added to the HTTP request for the
+          AJAX push. None are applied by default.
+        """
+        logging.Handler.__init__(self)
+        raise NotImplementedError("Not Tested")
+        method = method.upper()
+        if method not in ["GET", "POST"]:
+            raise ValueError("method must be GET or POST")
+        self.url = url
+        self.method = method
+        self.headers = headers
+
+    def mapLogRecord(self, record):
+        """
+        Default implementation of mapping the log record into a dict
+        that is sent as the CGI data. Overwrite in your class.
+        Contributed by Franz Glasner.
+        """
+        return record.__dict__
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Send the record to the Web server as a percent-encoded dictionary
+        """
+        try:
+            url = self.url
+            data = ""
+            # urllib does not exist.
+            #data = urllib.parse.urlencode(self.mapLogRecord(record))
+            if self.method == "GET":
+                if (url.find('?') >= 0):
+                    sep = '&'
+                else:
+                    sep = '?'
+                url = url + "%c%s" % (sep, data)
+            else: "POST"
+              # encode data here
+                pass
+
+            def ajaxCallback():
+                # @note - we should probably do something
+                #   like keep track of error messages and
+                #   provide a counter of failed pushes ?
+                pass
+
+            __pragma__('js', '{}',
+            '''
+            var x = new(this.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
+            x.open(data ? 'POST' : 'GET', url, 1);
+            x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+            x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+            x.onreadystatechange = ajaxCallback
+            x.send(data)
+            ''')
+
+
+        except Exception:
+            self.handleError(record)
+
+class BufferingHandler(logging.Handler):
+    """
+    A handler class which buffers logging records in memory. Whenever each
+    record is added to the buffer, a check is made to see if the buffer should
+    be flushed. If it should, then flush() is expected to do what's needed.
+    """
+    def __init__(self, capacity):
+        """
+        Initialize the handler with the buffer size.
+        """
+        logging.Handler.__init__(self)
+        self.capacity = capacity
+        self.buffer = []
+
+    def shouldFlush(self, record):
+        """
+        Should the handler flush its buffer?
+
+        Returns true if the buffer is up to capacity. This method can be
+        overridden to implement custom flushing strategies.
+        """
+        return (len(self.buffer) >= self.capacity)
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Append the record. If shouldFlush() tells us to, call flush() to process
+        the buffer.
+        """
+        self.buffer.append(record)
+        if self.shouldFlush(record):
+            self.flush()
+
+    def flush(self):
+        """
+        Override to implement custom flushing behaviour.
+
+        This version just zaps the buffer to empty.
+        """
+        self.acquire()
+        try:
+            self.buffer = []
+        except Exception exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            self.release()
+
+    def close(self):
+        """
+        Close the handler.
+
+        This version just flushes and chains to the parent class' close().
+        """
+        try:
+            self.flush()
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            logging.Handler.close(self)
+
+class MemoryHandler(BufferingHandler):
+    """
+    A handler class which buffers logging records in memory, periodically
+    flushing them to a target handler. Flushing occurs whenever the buffer
+    is full, or when an event of a certain severity or greater is seen.
+    """
+    def __init__(self, capacity, flushLevel=logging.ERROR, target=None,
+                             flushOnClose=True):
+        """
+        Initialize the handler with the buffer size, the level at which
+        flushing should occur and an optional target.
+
+        Note that without a target being set either here or via setTarget(),
+        a MemoryHandler is no use to anyone!
+
+        The ``flushOnClose`` argument is ``True`` for backward compatibility
+        reasons - the old behaviour is that when the handler is closed, the
+        buffer is flushed, even if the flush level hasn't been exceeded nor the
+        capacity exceeded. To prevent this, set ``flushOnClose`` to ``False``.
+        """
+        BufferingHandler.__init__(self, capacity)
+        self.flushLevel = flushLevel
+        self.target = target
+        # See Issue #26559 for why this has been added
+        self.flushOnClose = flushOnClose
+
+    def shouldFlush(self, record):
+        """
+        Check for buffer full or a record at the flushLevel or higher.
+        """
+        return (len(self.buffer) >= self.capacity) or \
+            (record.levelno >= self.flushLevel)
+
+    def setTarget(self, target):
+        """
+        Set the target handler for this handler.
+        """
+        self.target = target
+
+    def flush(self):
+        """
+        For a MemoryHandler, flushing means just sending the buffered
+        records to the target, if there is one. Override if you want
+        different behaviour.
+
+        The record buffer is also cleared by this operation.
+        """
+        self.acquire()
+        try:
+            if self.target:
+                for record in self.buffer:
+                    self.target.handle(record)
+                self.buffer = []
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            self.release()
+
+    def close(self):
+        """
+        Flush, if appropriately configured, set the target to None and lose the
+        buffer.
+        """
+        try:
+            if self.flushOnClose:
+                self.flush()
+        except Exception as exc: # @note - this is a hack around bug in transcrypt
+            raise exc
+        finally:
+            self.acquire()
+            try:
+                self.target = None
+                BufferingHandler.close(self)
+            except Exception as exc: # @note - this is a hack around bug in transcrypt
+                raise exc
+
+            finally:
+                self.release()
+
+
+class QueueHandler(logging.Handler):
+    """
+    This handler sends events to a queue. Typically, it would be used together
+    with a multiprocessing Queue to centralise logging to file in one process
+    (in a multi-process application), so as to avoid file write contention
+    between processes.
+
+    For transcrypt, this maybe useful for implementing a web worker in
+    the background for processing logs and sending them to the server or
+    elsewhere without blocking the main task.
+
+    This code is new in Python 3.2, but this class can be copy pasted into
+    user code for use with earlier Python versions.
+    """
+
+    def __init__(self, queue):
+        """
+        Initialise an instance, using the passed queue.
+        """
+        logging.Handler.__init__(self)
+        raise NotImplementedError("No Working Implementation Yet")
+        self.queue = queue
+
+    def enqueue(self, record):
+        """
+        Enqueue a record.
+
+        The base implementation uses put_nowait. You may want to override
+        this method if you want to use blocking, timeouts or custom queue
+        implementations.
+
+        In transcrypt we will likely want to use a push to a webworker
+        here instead of a normal queue.
+        """
+        self.queue.put_nowait(record)
+
+    def prepare(self, record):
+        """
+        Prepares a record for queuing. The object returned by this method is
+        enqueued.
+
+        The base implementation formats the record to merge the message
+        and arguments, and removes unpickleable items from the record
+        in-place.
+
+        You might want to override this method if you want to convert
+        the record to a dict or JSON string, or send a modified copy
+        of the record while leaving the original intact.
+        """
+        # The format operation gets traceback text into record.exc_text
+        # (if there's exception data), and also puts the message into
+        # record.message. We can then use this to replace the original
+        # msg + args, as these might be unpickleable. We also zap the
+        # exc_info attribute, as it's no longer needed and, if not None,
+        # will typically not be pickleable.
+        self.format(record)
+        record.msg = record.message
+        record.args = None
+        record.exc_info = None
+        return record
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Writes the LogRecord to the queue, preparing it for pickling first.
+        """
+        try:
+            self.enqueue(self.prepare(record))
+        except Exception:
+            self.handleError(record)


### PR DESCRIPTION
This commit includes an initial implementation of the logging module and addresses Issue #174. It
includes a basic unit test for the logger only. The `logging.basicConfig`
and `logging.config.dictConfig` methods are not tested at this point.

I've stubbed in placeholders for some additional logging.Handler objects
that I think could be useful in the future but these are not tested
yet.

The provided unit test inserts a new TestHandler object that calls the AutoTester `check` method. Part of the tests also inserts a StreamHandler and allows manual inspection of the console.log but I haven't thought of a good way to test that other than manually. 