### PR TITLE
Logging Config Baseline Implementation

### DIFF
--- a/transcrypt/development/automated_tests/logging/autotest.py
+++ b/transcrypt/development/automated_tests/logging/autotest.py
@@ -4,9 +4,15 @@ from org.transcrypt.stubs.browser import __pragma__
 import org.transcrypt.autotester
 
 import logger_tests
+import config_tests
+import basicConfig_tests
+import buffering_tests
 
 autoTester = org.transcrypt.autotester.AutoTester ()
 
 autoTester.run( logger_tests, "logger_tests" )
+autoTester.run( config_tests, "config_tests" )
+autoTester.run( basicConfig_tests, "basicConfig_tests" )
+autoTester.run( buffering_tests, "buffering_tests")
 
 autoTester.done()

--- a/transcrypt/development/automated_tests/logging/basicConfig_tests.py
+++ b/transcrypt/development/automated_tests/logging/basicConfig_tests.py
@@ -1,0 +1,36 @@
+# This file contains some unit tests for the logging.basicConfig
+# method.
+
+from org.transcrypt.stubs.browser import __pragma__, __envir__
+import logging
+from utils import TestHandler, resetLogging
+
+def run(test):
+    """
+    """
+    resetLogging()
+
+    basehdlr = TestHandler(test, 5)
+    fmt = logging.Formatter(style="{")
+    basehdlr.setFormatter(fmt)
+
+    logging.basicConfig(handlers = [basehdlr], level=logging.INFO)
+
+    root = logging.getLogger()
+    test.check(root.hasHandlers())
+    test.check(root.level)
+    test.check(len(root.handlers))
+    hdlr = root.handlers[0]
+    test.check(hdlr.level)
+
+    logging.debug("Never gonna give you up")
+    logging.info("Never gonna let you go")
+    logging.warning("Never gonna run around and desert you")
+    logging.error("Never gonna make you cry")
+
+    root.setLevel(logging.DEBUG)
+
+    logging.debug("Never gonna give you up")
+    logging.info("Never gonna let you go")
+    logging.warning("Never gonna run around and desert you")
+    logging.error("Never gonna make you cry")

--- a/transcrypt/development/automated_tests/logging/buffering_tests.py
+++ b/transcrypt/development/automated_tests/logging/buffering_tests.py
@@ -1,0 +1,79 @@
+
+
+import logging
+import logging.handlers as hdlr
+from utils import TestHandler, resetLogging
+
+class DemoBufferingFormatter(logging.BufferingFormatter):
+    """
+    """
+    def formatHeader( self, records):
+        """
+        """
+        return "------ {} Records ------\n".format(len(records))
+
+
+class BetterBufferingHandler(hdlr.MemoryHandler):
+
+    def flush(self):
+        """ Overriding the flush method so that we can
+        test with the BufferingFormatter objects"""
+        self.acquire()
+        try:
+            if self.target:
+                if self.formatter:
+                    aggregate = self.formatter.format(self.buffer)
+                    self.target.handle(aggregate)
+                else:
+                    raise NotImplementedError()
+            self.buffer = []
+        except Exception:
+            raise
+        finally:
+            self.release()
+
+class TestBuffering(logging.Handler):
+    def __init__(self, test):
+        logging.Handler.__init__(self)
+        self._test = test
+
+    def emit(self, record):
+        msg = record
+        self._test.check(msg)
+
+
+def run(test):
+    """ This tests the buffering handlers which will be
+    important for the AJAX and possibly other loggin handlers.
+    """
+
+    resetLogging()
+    thdlr = TestBuffering(test)
+    thdlr.setLevel(2)
+
+
+    bufHdlr = BetterBufferingHandler(3)
+    linefmt = logging.Formatter("{levelname}:{message}", style="{")
+    fmt = DemoBufferingFormatter(linefmt)
+    bufHdlr.setFormatter(fmt)
+    bufHdlr.setTarget(thdlr)
+
+    root = logging.getLogger()
+    root.setLevel(5)
+    root.addHandler(bufHdlr)
+
+    root.debug("One")
+    root.info("Dos")
+    root.warning("Tres")
+
+    root.debug("One")
+    root.info("Dos")
+    root.warning("Tres")
+
+    root.debug("One")
+    root.info("Dos")
+    root.warning("Tres")
+
+    root.debug("One")
+    root.error("Dos")
+    root.error("Tres")

--- a/transcrypt/development/automated_tests/logging/config_tests.py
+++ b/transcrypt/development/automated_tests/logging/config_tests.py
@@ -1,0 +1,132 @@
+from org.transcrypt.stubs.browser import __pragma__, __envir__
+from utils import TestHandler, resetLogging
+import logging
+import logging.config
+
+__pragma__("kwargs")
+
+class TestFilter(logging.Filter):
+    """ This a test of the custom filter object concept
+    """
+    def __init__(self, modulo):
+        """
+        """
+        if ( modulo <= 0 ):
+            raise ValueError("Invalid Modulo Value")
+        self._modulo = modulo
+        self._cnt = 0
+
+    def filter(self, record):
+        """
+        """
+        ret = False
+        self._cnt += 1
+        if ( self._cnt > self._modulo  ):
+            self._cnt = 0
+            ret = True
+        return(ret)
+
+
+class TestFormatter(logging.Formatter):
+    """This a test of the custom formatter object concept
+    """
+    def __init__(self, format=None, datefmt=None, style='{'):
+        """
+        """
+        logging.Formatter.__init__(self, format, datefmt, style)
+
+    def format(self, record):
+        """ Override the format Method
+        """
+        msg = logging.Formatter.format(self, record)
+        msg = "Custom: " + msg
+        return(msg)
+
+def run(test):
+    """
+    """
+    resetLogging()
+
+    d = {
+        "version" : 1,
+        "formatters": {
+            "fmt1" : {
+                "format": "{levelname}:{asctime}:{name}:{message}",
+                "datefmt": "%H:%M:%S",
+                "style": "{",
+            },
+            "fmt2" : {
+                "format" : "{name}_{levelname}_{message}",
+                "style": "{",
+            },
+            "fmt3" : {
+                "()" : TestFormatter,
+                "format" : "[{name}]_{message}",
+                "style" : "{",
+            },
+        },
+        "filters" : {
+            "filt1": {
+                '()': TestFilter,
+                'modulo': 2,
+            },
+        },
+        "handlers" : {
+            "hdlr1": {
+                "class": "logging.StreamHandler", #TestHandler,
+                "formatter": "fmt1",
+                "level": "DEBUG",
+                "filters": ["filt1"],
+            },
+            "hdlr2": {
+                "class" : "utils.TestHandler",
+                "formatter": "fmt2",
+                "filters": [],
+                "level": "WARNING",
+                "test" : test,
+                "lvl" : 1,
+            },
+            "hdlr3": {
+                "class" : "utils.TestHandler",
+                "formatter": "fmt3",
+                "level": "INFO",
+                "test" : test,
+                "lvl" : 2,
+            },
+        },
+        'root': {
+            'level': "INFO",
+            'handlers': ["hdlr1"]
+        },
+        "loggers": {
+            "test1": {
+                "level": 30,
+                "filters": [],
+                "handlers": ["hdlr2", "hdlr3"],
+            },
+        }
+    }
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logging.config.addResolvable("utils.TestHandler", TestHandler)
+
+    logging.config.dictConfig(d)
+    tlog = logging.getLogger("test1")
+
+    test.check( len(tlog.handlers) )
+    test.check( len(tlog.filters) )
+    test.check( tlog.level )
+
+
+    for i in range(0, 10):
+        logging.debug("1234")
+        logging.info("asdf")
+        logging.warning("ioureoiu")
+        logging.error("jekwejrjek")
+        logging.critical("jlkjelkjwelkr")
+
+        tlog.debug("1234")
+        tlog.info("asdf")
+        tlog.warning("ioureoiu")
+        tlog.error("jekwejrjek")
+        tlog.critical("jlkjelkjwelkr")

--- a/transcrypt/development/automated_tests/logging/logger_tests.py
+++ b/transcrypt/development/automated_tests/logging/logger_tests.py
@@ -1,36 +1,13 @@
 
 from org.transcrypt.stubs.browser import __pragma__, __envir__
 
-#from logging import *
 import logging
-#import logging as log
-
-class TestHandler(logging.Handler):
-    """ This handler is intended to make it easier to test the
-    logging module output without requiring the console or the
-    sys.stderr.
-    """
-    def __init__(self, test, level):
-        """
-        """
-        logging.Handler.__init__(self, level)
-        self._test = test
-
-    def emit(self, record):
-        """
-        """
-        msg = self.format(record)
-        self._test.check(msg)
+from utils import TestHandler, resetLogging
 
 
 def logger_basics(test):
-    # @note - basicConfig has some issues because the
-    #   kwargs parameter is difficult work
-    # basehdlr = TestHandler(test, 0)
-    # fmt = logging.Formatter(style="{")
-    # basehdlr.setFormatter(fmt)
 
-    # logging.basicConfig(handlers = [basehdlr])
+    resetLogging()
 
     logger = logging.getLogger("tester")
     test.check(logger.name)
@@ -118,6 +95,8 @@ def logger_basics(test):
 
 def logging_api_tests(test):
 
+    resetLogging()
+
     logger = logging.getLogger()
     logger.setLevel(20)
     hdlr = TestHandler(test, 30)
@@ -183,11 +162,14 @@ def logging_api_tests(test):
 def formatter_tests(test):
     """ This function contains some tests of the formatter objects
     """
+
+    resetLogging()
+
     logger = logging.getLogger("fmttest")
     logger.setLevel(10)
 
     hdlr = TestHandler(test, 30)
-    fmt = logging.Formatter(style="{", fmt="{levelname}:{name}:{message}")
+    fmt = logging.Formatter("{levelname}:{name}:{message}", style="{")
     test.check(fmt.usesTime())
     hdlr.setFormatter(fmt)
     logger.addHandler(hdlr)
@@ -220,12 +202,14 @@ def console_test(test):
     autotester results but can be manually inspected in the
     console.log
     """
+    resetLogging()
+
     logger = logging.getLogger("consoleTest")
 
     logger.setLevel(10)
 
     hdlr = TestHandler(test, 30)
-    fmt = logging.Formatter(style="{", fmt="{name}:{message}")
+    fmt = logging.Formatter("{name}:{message}", style="{")
     test.check(fmt.usesTime())
     hdlr.setFormatter(fmt)
     hdlr.setLevel(20)
@@ -269,7 +253,7 @@ def placeholder_testing(test):
     logger.setLevel(10)
 
     hdlr = TestHandler(test, 5)
-    fmt = logging.Formatter(style="{", fmt="{levelname}:{name}:{message}")
+    fmt = logging.Formatter("{levelname}:{name}:{message}", style="{")
     hdlr.setFormatter(fmt)
     logger.addHandler(hdlr)
 

--- a/transcrypt/development/automated_tests/logging/utils.py
+++ b/transcrypt/development/automated_tests/logging/utils.py
@@ -1,0 +1,46 @@
+# Utilities for implementating the unit tests for the
+# logging module.
+#
+from org.transcrypt.stubs.browser import __pragma__, __envir__
+import logging
+
+__pragma__("kwargs")
+
+class TestHandler(logging.Handler):
+    """ This handler is intended to make it easier to test the
+    logging module output without requiring the console or the
+    sys.stderr.
+    """
+    def __init__(self, test, lvl):
+        """
+        @param test AutoTester object that messages will
+          be logged to for unit testing.
+        @param level logging level that will be filtered.
+        """
+        logging.Handler.__init__(self, lvl)
+        self._test = test
+
+    def emit(self, record):
+        """
+        """
+        msg = self.format(record)
+        self._test.check(msg)
+
+def resetLogging():
+    """ Reset the handlers and loggers so that we
+    can rerun the tests starting from a blank slate.
+    """
+    __pragma__("skip")
+    logging._handlerList = []
+
+    import weakref
+    logging._handlers = weakref.WeakValueDictionary()
+
+    logging.root = logging.RootLogger(logging.WARNING)
+    logging.Logger.root = logging.root
+    logging.Logger.manager = logging.Manager(logging.root)
+    logging.root.manager = logging.Logger.manager
+    __pragma__("noskip")
+
+    if __envir__.executor_name == __envir__.transpiler_name:
+        logging._resetLogging()

--- a/transcrypt/modules/logging/__init__.py
+++ b/transcrypt/modules/logging/__init__.py
@@ -558,7 +558,7 @@ class Formatter(object):
 
     converter = time.localtime
     __pragma__('kwargs')
-    def __init__(self, fmt=None, datefmt=None, style='{'):
+    def __init__(self, format=None, datefmt=None, style='{'):
         """
         Initialize the formatter with specified format strings.
 
@@ -578,7 +578,7 @@ class Formatter(object):
         if ( style != '{' ):
             raise NotImplementedError("{} format only")
 
-        self._style = _STYLES[style][0](fmt)
+        self._style = _STYLES[style][0](format)
         self._fmt = self._style._fmt
         self.datefmt = datefmt
 
@@ -875,8 +875,6 @@ def _removeHandlerRef(wr):
         try:
             if wr in handlers:
                 handlers.remove(wr)
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             release()
 
@@ -888,8 +886,6 @@ def _addHandlerRef(handler):
     try:
         _handlerList.append(handler)
 #        _handlerList.append(weakref.ref(handler, _removeHandlerRef))
-    except Exception as exc: # @note - this is a hack around bug in transcrypt
-        raise exc
     finally:
         _releaseLock()
 
@@ -926,8 +922,6 @@ class Handler(Filterer):
             self._name = name
             if name:
                 _handlers[name] = self
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             _releaseLock()
 
@@ -1000,9 +994,6 @@ class Handler(Filterer):
             self.acquire()
             try:
                 self.emit(record)
-            except Exception as exc: # @note - this is a hack around bug in transcrypt
-                raise exc
-
             finally:
                 self.release()
         return rv
@@ -1036,8 +1027,6 @@ class Handler(Filterer):
         try:        #unlikely to raise an exception, but you never know...
             if self._name and self._name in _handlers:
                 del _handlers[self._name]
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             _releaseLock()
 
@@ -1090,8 +1079,6 @@ class StreamHandler(Handler):
         try:
             if self.stream and hasattr(self.stream, "flush"):
                 self.stream.flush()
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             self.release()
 
@@ -1246,8 +1233,6 @@ class Manager(object):
                 rv.manager = self
                 self.loggerDict[name] = rv
                 self._fixupParents(rv)
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             _releaseLock()
         return rv
@@ -1530,8 +1515,6 @@ class Logger(Filterer):
         try:
             if not (hdlr in self.handlers):
                 self.handlers.append(hdlr)
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             _releaseLock()
 
@@ -1543,8 +1526,6 @@ class Logger(Filterer):
         try:
             if hdlr in self.handlers:
                 self.handlers.remove(hdlr)
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             _releaseLock()
 
@@ -1850,48 +1831,31 @@ def basicConfig(**kwargs):
     _acquireLock()
     try:
         if len(root.handlers) == 0:
-            handlers = kwargs["handlers"]
-            # @note - kwargs as the function args does not seem to
-            #     be a full-fledged dict
-            #handlers = kwargs.pop("handlers", None)
+            handlers = kwargs.pop("handlers", None)
             if handlers is not None:
                 if "stream" in kwargs:
                     raise ValueError("'stream' should not be "
-                                                     "specified together with 'handlers'")
+                                     "specified together with 'handlers'")
             if handlers is None:
-                stream = kwargs["stream"]
-                #stream = kwargs.pop("stream", None)
+                stream = kwargs.pop("stream", None)
                 h = StreamHandler(stream)
                 handlers = [h]
-            dfs = kwargs["datefmt"]
-            #dfs = kwargs.pop("datefmt", None)
-            style = kwargs["style"]
-            if ( style is None ):
-                style = "{"
-            #style = kwargs.pop("style", '{')
+            dfs = kwargs.pop("datefmt", None)
+            style = kwargs.pop("style", '{')
             if style not in _STYLES:
                 raise ValueError('Style must be one of: {}'.format(','.join(_STYLES.keys())))
-            fs = kwargs["format"]
-            if ( fs is None ):
-                fs = _STYLES[style][1]
-            #fs = kwargs.pop("format", _STYLES[style][1])
+            fs = kwargs.pop("format", _STYLES[style][1])
             fmt = Formatter(fs, dfs, style)
             for h in handlers:
                 if h.formatter is None:
                     h.setFormatter(fmt)
                 root.addHandler(h)
-            level = kwargs["level"]
-            #level = kwargs.pop("level", None)
+            level = kwargs.pop("level", None)
             if level is not None:
                 root.setLevel(level)
-            # @todo - currently we don't have a full dict object
-            # in kwargs - so we have to make sacrifices.
-            #if kwargs:
-            #    keys = ', '.join(kwargs.keys())
-            #    raise ValueError('Unrecognised argument(s): {}'.format(keys))
-    except Exception as exc: # @note - this is a hack around bug in transcrypt
-        raise exc
-
+            if len(kwargs) > 0:
+                keys = ', '.join(kwargs.keys())
+                raise ValueError('Unrecognised argument(s): {}'.format(keys))
     finally:
         _releaseLock()
 

--- a/transcrypt/modules/logging/__init__.py
+++ b/transcrypt/modules/logging/__init__.py
@@ -1786,6 +1786,21 @@ Logger.manager = Manager(Logger.root)
 # instances of a class
 root.manager = Logger.manager
 
+def _resetLogging():
+    """ This is a utility method to help with testing so that
+    we can start from a clean slate.
+    """
+    _handlerList = []
+    _handlers = {}
+    global root
+    root = RootLogger(WARNING)
+    Logger.root = root
+    Logger.manager = Manager(Logger.root)
+    # @note - this is necessary because I think there may be a bug
+    # in the way that class level attributes are distributed to
+    # instances of a class
+    root.manager = Logger.manager
+
 #---------------------------------------------------------------------------
 # Configuration classes and functions
 #---------------------------------------------------------------------------

--- a/transcrypt/modules/logging/handlers.py
+++ b/transcrypt/modules/logging/handlers.py
@@ -81,13 +81,13 @@ class AJAXHandler(logging.Handler):
           AJAX push. None are applied by default.
         """
         logging.Handler.__init__(self)
-        raise NotImplementedError("Not Tested")
         method = method.upper()
         if method not in ["GET", "POST"]:
             raise ValueError("method must be GET or POST")
         self.url = url
         self.method = method
         self.headers = headers
+        raise NotImplementedError("Not Tested")
 
     def mapLogRecord(self, record):
         """
@@ -114,26 +114,25 @@ class AJAXHandler(logging.Handler):
                 else:
                     sep = '?'
                 url = url + "%c%s" % (sep, data)
-            else: "POST"
-              # encode data here
-                pass
+            else: # "POST"
+                # encode data here
+                url = "asdf"
 
             def ajaxCallback():
                 # @note - we should probably do something
                 #   like keep track of error messages and
                 #   provide a counter of failed pushes ?
-                pass
+                return(0)
 
             __pragma__('js', '{}',
-            '''
+                       '''
             var x = new(this.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
             x.open(data ? 'POST' : 'GET', url, 1);
             x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
             x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
             x.onreadystatechange = ajaxCallback
             x.send(data)
-            ''')
-
+                       ''')
 
         except Exception:
             self.handleError(record)
@@ -181,8 +180,6 @@ class BufferingHandler(logging.Handler):
         self.acquire()
         try:
             self.buffer = []
-        except Exception exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             self.release()
 
@@ -194,8 +191,6 @@ class BufferingHandler(logging.Handler):
         """
         try:
             self.flush()
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             logging.Handler.close(self)
 
@@ -252,8 +247,6 @@ class MemoryHandler(BufferingHandler):
                 for record in self.buffer:
                     self.target.handle(record)
                 self.buffer = []
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             self.release()
 
@@ -265,16 +258,11 @@ class MemoryHandler(BufferingHandler):
         try:
             if self.flushOnClose:
                 self.flush()
-        except Exception as exc: # @note - this is a hack around bug in transcrypt
-            raise exc
         finally:
             self.acquire()
             try:
                 self.target = None
                 BufferingHandler.close(self)
-            except Exception as exc: # @note - this is a hack around bug in transcrypt
-                raise exc
-
             finally:
                 self.release()
 
@@ -300,7 +288,7 @@ class QueueHandler(logging.Handler):
         """
         logging.Handler.__init__(self)
         raise NotImplementedError("No Working Implementation Yet")
-        self.queue = queue
+        #self.queue = queue
 
     def enqueue(self, record):
         """

--- a/transcrypt/modules/re/__init__.py
+++ b/transcrypt/modules/re/__init__.py
@@ -680,12 +680,10 @@ class Regex(object):
                     # subsequent match
                     ret += string[lastEnd:m.index]
 
-                try:
+                if callable(repl):
                     content = repl(Match(m, string, 0, len(string), self, self._groupindex))
                     ret += content
-                except:
-                    # repl is likely not callable so - we will
-                    # instead try to use it as a string
+                else:
                     ret += repl
 
                 totalMatch+=1


### PR DESCRIPTION
This PR contains updates to the the `logging` module to add basic functionality for `basicConfig` and `dictConfig`. I've added basic unit tests for these features and I've additionally added some unit tests for the buffering handlers.

This PR also contains a minor update to the `re` module to update it to the latest support of `callable` which wasn't available earlier.

This commit primarily addresses issue #174 