### PR TITLE
Manual test for AJAX handler and cleanup of config

### DIFF
--- a/transcrypt/development/manual_tests/module_logging/README.md
+++ b/transcrypt/development/manual_tests/module_logging/README.md
@@ -1,0 +1,50 @@
+Logging AJAX Handler Manuall Test
+=================================
+
+This directory contains the following:
+
+1. `ajaxlogclient.(html|py)` - A transcrypt-based web-page that sets up a logger using the `logging` module and adds two handlers. The first is a custom HTML Handler for showing log messages on the screen. The second is an AJAX Handler that pushes messages to a server. This file can be loaded from the filesystem by firefox or chrome.
+2. `ajaxlogserver.py` - A small test server script that acts as an endpoint to receive the AJAX Handler log messages.
+
+
+To run the test, do the following:
+
+1. Compile the transcript webpage
+
+```
+  $> transcrypt -e 5 ajaxlogclient.py
+```
+
+2. Run the server endpoint:
+
+```
+  $> ./ajaxlogserver.py
+```
+
+3. Load the webpage in a browser:
+
+```
+  $> firefox ajaxlogclient.html
+```
+
+4. Check that the output looks like you expect it to look:
+
+Server Endpoint Output:
+
+```
+$> ./ajaxlogserver.py
+running server...
+MSG: ['INFO[08:59:49]: Started AJAX Logger']
+127.0.0.1 - - [30/Nov/2016 08:59:49] "POST /log HTTP/1.1" 200 -
+MSG: ['INFO[08:59:50]: Message on The Bus goes Round and Round']
+127.0.0.1 - - [30/Nov/2016 08:59:50] "POST /log HTTP/1.1" 200 -
+MSG: ['INFO[08:59:51]: Message on The Bus goes Round and Round']
+127.0.0.1 - - [30/Nov/2016 08:59:51] "POST /log HTTP/1.1" 200 -
+MSG: ['INFO[08:59:52]: Message on The Bus goes Round and Round']
+127.0.0.1 - - [30/Nov/2016 08:59:52] "POST /log HTTP/1.1" 200 -
+MSG: ['INFO[08:59:53]: Message on The Bus goes Round and Round']
+```
+
+Browser Client Output:
+
+<Image Goes Here>

--- a/transcrypt/development/manual_tests/module_logging/README.md
+++ b/transcrypt/development/manual_tests/module_logging/README.md
@@ -47,4 +47,4 @@ MSG: ['INFO[08:59:53]: Message on The Bus goes Round and Round']
 
 Browser Client Output:
 
-<Image Goes Here>
+![Image of Browser Test Output](https://cloud.githubusercontent.com/assets/15036736/20763406/c6c1b1ac-b6de-11e6-9283-fbfd7f003e3b.png)

--- a/transcrypt/development/manual_tests/module_logging/ajaxlogclient.html
+++ b/transcrypt/development/manual_tests/module_logging/ajaxlogclient.html
@@ -1,0 +1,17 @@
+<html>
+
+  <head>
+    <title> AJAX Logging Handler Test </title>
+  </head>
+  <body>
+
+    <H2> Log Messages </H2>
+
+    <ul id="log-output">
+
+    </ul>
+
+    <script src="__javascript__/ajaxlogclient.js"> </script>
+
+  </body>
+</html>

--- a/transcrypt/development/manual_tests/module_logging/ajaxlogclient.py
+++ b/transcrypt/development/manual_tests/module_logging/ajaxlogclient.py
@@ -1,0 +1,66 @@
+# File: ajaxlogclient.py
+# Author: Carl Allendorph
+# Date: 29NOV2016
+#
+# Description:
+#    This file contains the implementation of a logging client
+# to test the ajax logging handler
+
+import logging
+import logging.handlers as loghdlr
+
+
+class HTMLHandler(logging.Handler):
+    """ This handler is used to provide a view on the screen of the
+    logging messages that have been sent over the AJAX handler. This
+    is primarily for debugging purposes.
+    """
+    def __init__(self, elemId):
+        """ Configure the HTML Handler
+        @param elemId parent element where we will start pushing
+        logging messages.
+        """
+        logging.Handler.__init__(self)
+        self._elem = document.getElementById(elemId)
+
+    def emit(self, record):
+        msg = self.format(record)
+        if self._elem:
+            node = document.createElement("LI")
+            content = document.createTextNode(msg)
+            node.appendChild(content)
+            self._elem.appendChild(node)
+
+
+def setupLogger():
+    root = logging.getLogger()
+    root.setLevel(10)
+
+    fmt = logging.Formatter("{levelname}[{asctime}]: {message}","%H:%M:%S", style="{")
+
+    headers = [
+        ('X-Requested-With', 'XMLHttpRequest'),
+        ('Content-type', 'application/x-www-form-urlencoded'),
+        ]
+
+    ahdlr = loghdlr.AJAXHandler("http://127.0.0.1:8081/log", "POST")
+    #ahdlr = loghdlr.AJAXHandler("/log")
+    ahdlr.setLevel(10)
+    ahdlr.setFormatter(fmt)
+
+    htmlHdlr = HTMLHandler("log-output")
+    htmlHdlr.setLevel(10)
+    htmlHdlr.setFormatter(fmt)
+
+    root.addHandler(ahdlr)
+    root.addHandler(htmlHdlr)
+
+    logging.info("Started AJAX Logger")
+
+
+setupLogger()
+
+def logPeriodic():
+    logging.info("Message on The Bus goes Round and Round")
+
+setInterval(logPeriodic, 1000)

--- a/transcrypt/development/manual_tests/module_logging/ajaxlogserver.py
+++ b/transcrypt/development/manual_tests/module_logging/ajaxlogserver.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# File: logAjax.py
+# Author: Carl Allendorph
+
+import argparse
+import http.server
+from urllib.parse import urlparse, parse_qs
+
+def setup_options():
+    parser = argparse.ArgumentParser(description="Simple Ajax Logger Test Server")
+    parser.add_argument("--host", dest="host", default="127.0.0.1",
+                        help="Which network interface this server will bind to. Default is %(default)s")
+    parser.add_argument("--port", dest="port", default=8081,type=int,
+                        help="The port that the HTTP server will bind to.")
+    args = parser.parse_args()
+    return(args)
+
+
+class reqHandler(http.server.BaseHTTPRequestHandler):
+
+    def print_log(self, qdata):
+        if "msg" in qdata:
+            print("MSG: %s" % qdata["msg"])
+        else:
+            print("ERROR: No Message")
+
+
+    def do_GET(self):
+        self.send_response(200)
+
+        p = urlparse(self.path)
+        qdata = parse_qs(p.query)
+        self.print_log(qdata)
+
+        self.send_header('Content-type','text/plain')
+        self.end_headers()
+
+        self.wfile.write(bytes("OK", "utf8"))
+        return
+
+    def do_POST(self):
+
+        data = self.rfile.read(int(self.headers['Content-Length']))
+        data = data.decode('utf-8')
+        qdata = parse_qs(data)
+        self.print_log(qdata)
+
+        self.send_response(200)
+        self.send_header('Content-type','text/plain')
+        self.end_headers()
+
+        self.wfile.write(bytes("OK", "utf8"))
+        return
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header("Access-Control-Allow-Headers", "X-Requested-With")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+
+if __name__ == "__main__":
+
+    opts = setup_options()
+
+    addr = (opts.host, opts.port)
+    httpd = http.server.HTTPServer(addr, reqHandler)
+    print('running server...')
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("exiting...")

--- a/transcrypt/modules/logging/config.py
+++ b/transcrypt/modules/logging/config.py
@@ -39,6 +39,9 @@ This module adds the method `addResolvable` which allows the user
 to add new class objects that can be included in the dict config
 by string representation. See the unit tests for an example
 
+The converter syntax, e.g. `cfg:\\handlers.hdlr1`, is not tested at
+this point and will throw an "NotImplemented" exception if a converter
+sequence is encountered.
 
 """
 
@@ -343,9 +346,10 @@ class BaseConfigurator(object):
                 prefix = d[1] # prefix
                 converter = self.value_converters.get(prefix, None)
                 if converter:
-                    suffix = d[2] # suffix
-                    converter = getattr(self, converter)
-                    value = converter(suffix)
+                    raise NotImplementedError("Converters Not Well Tested!")
+                    #suffix = d[2] # suffix
+                    #converter = getattr(self, converter)
+                    #value = converter(suffix)
         return value
 
     def configure_custom(self, config):

--- a/transcrypt/modules/logging/handlers.py
+++ b/transcrypt/modules/logging/handlers.py
@@ -37,7 +37,7 @@ This code is not well tested yet!
 
 from org.transcrypt.stubs.browser import __pragma__
 import logging
-#import time, re
+import re
 
 #from stat import ST_DEV, ST_INO, ST_MTIME
 #import queue
@@ -56,8 +56,8 @@ DEFAULT_TCP_LOGGING_PORT        = 9020
 DEFAULT_UDP_LOGGING_PORT        = 9021
 DEFAULT_HTTP_LOGGING_PORT       = 9022
 DEFAULT_SOAP_LOGGING_PORT       = 9023
-SYSLOG_UDP_PORT                         = 514
-SYSLOG_TCP_PORT                         = 514
+SYSLOG_UDP_PORT                 = 514
+SYSLOG_TCP_PORT                 = 514
 
 _MIDNIGHT = 24 * 60 * 60    # number of seconds in a day
 
@@ -87,7 +87,7 @@ class AJAXHandler(logging.Handler):
         self.url = url
         self.method = method
         self.headers = headers
-        raise NotImplementedError("Not Tested")
+
 
     def mapLogRecord(self, record):
         """
@@ -97,26 +97,48 @@ class AJAXHandler(logging.Handler):
         """
         return record.__dict__
 
+    def urlencode(self, msg):
+        """ Encode the passed string with escapes for
+        non-valid characters in a url.
+        """
+        def repl(m):
+            v = m.group(0)
+            v = ord(v)
+            hVal = v.toString(16)
+            if ( len(hVal) == 1 ):
+                hVal = "0" + hVal
+            # Convert this value from a character into
+            # %xx format
+            hVal = "%" + hVal
+            return(hVal)
+
+        p = re.compile(r"[^-A-Za-z0-9\-\._~:/?#[\]@!$&'()\*+,;=`]")
+        ret = p.sub(repl,  msg)
+        return(ret)
+
     def emit(self, record):
         """
         Emit a record.
-
         Send the record to the Web server as a percent-encoded dictionary
         """
+        if ( type(record) is str ):
+            msg = record
+        else:
+            msg = self.format(record)
+
         try:
             url = self.url
-            data = ""
-            # urllib does not exist.
-            #data = urllib.parse.urlencode(self.mapLogRecord(record))
+            data = None
             if self.method == "GET":
                 if (url.find('?') >= 0):
                     sep = '&'
                 else:
                     sep = '?'
-                url = url + "%c%s" % (sep, data)
+                url = url + "{}msg={}".format(sep, msg)
+                url = self.urlencode(url)
             else: # "POST"
-                # encode data here
-                url = "asdf"
+                data = "msg={}".format(msg)
+                data = self.urlencode(data)
 
             def ajaxCallback():
                 # @note - we should probably do something
@@ -124,15 +146,30 @@ class AJAXHandler(logging.Handler):
                 #   provide a counter of failed pushes ?
                 return(0)
 
+
+            conn = None
+            errObj = None
             __pragma__('js', '{}',
                        '''
-            var x = new(this.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
-            x.open(data ? 'POST' : 'GET', url, 1);
-            x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-            x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-            x.onreadystatechange = ajaxCallback
-            x.send(data)
+                       try {
+                         conn = new(XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
+                       } catch( err ) {
+                         errObj = err
+                       }
                        ''')
+
+            if ( errObj is not None ):
+                raise Exception( "Failed Create AJAX Request", errObj )
+
+            if ( conn is None ):
+                raise Exception("Invalid Ajax Object")
+
+            conn.open(self.method, url, 1);
+            for key,val in self.headers:
+                conn.setRequestHeader( key, val )
+
+            conn.onreadystatechange = ajaxCallback
+            conn.send(data)
 
         except Exception:
             self.handleError(record)


### PR DESCRIPTION
This PR contains an update to the AJAX logging handler and a manual test for checking this feature. I've also made the converter syntax throw `NotImplementedError` as discussed because this code in `logging.config` is not well tested. 

I think this commit completes the basic necessities for the logging module and closes issue #174 . There are probably bugs and things we will have to fix but I think this gets us to a point where we can at least start testing it.