### PR TITLE
Make prettier 'else if' JavaScript statements

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -1956,13 +1956,18 @@ class Generator (ast.NodeVisitor):
         self.emit ('}}\n')
 
         if node.orelse:
-            self.adaptLineNrString (node.orelse)
+            if len (node.orelse) == 1 and node.orelse [0].__class__.__name__ == 'If':
+                # elif statement
+                self.emit ('else ')
+                self.visit (node.orelse[0])
+            else:
+                self.adaptLineNrString (node.orelse)
 
-            self.emit ('else {{\n')
-            self.indent ()
-            self.emitBody (node.orelse)
-            self.dedent ()
-            self.emit ('}}\n')
+                self.emit ('else {{\n')
+                self.indent ()
+                self.emitBody (node.orelse)
+                self.dedent ()
+                self.emit ('}}\n')
 
     def visit_IfExp (self, node):
         self.emit ('(')


### PR DESCRIPTION
This adds a special case to the "If" visitor for when the 'orelse' statement list only contains another single 'If' statement.

Take this source code, for example:

```
if a:
    print('a')
elif b:
    print('b')
elif c:
    print('c')
elif d:
    print('d')
elif e:
    print('e')
elif f:
    print('f')
elif g:
    print('g')
```

Without this patch, Transcrypt creates the following:

```
if (a) {
	print ('a');
}
else {
	if (b) {
		print ('b');
	}
	else {
		if (c) {
			print ('c');
		}
		else {
			if (d) {
				print ('d');
			}
			else {
				if (e) {
					print ('e');
				}
				else {
					if (f) {
						print ('f');
					}
					else {
						if (g) {
							print ('g');
						}
					}
				}
			}
		}
	}
}
```

With this patch, it would instead create:

```
if (a) {
	print ('a');
}
else if (b) {
	print ('b');
}
else if (c) {
	print ('c');
}
else if (d) {
	print ('d');
}
else if (e) {
	print ('e');
}
else if (f) {
	print ('f');
}
else if (g) {
	print ('g');
}
```

I'm not exactly sure if I should create a test for a patch like this, but if needed I can do that.