### PR TITLE
Add js_global to aliases

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -481,6 +481,7 @@ class Generator (ast.NodeVisitor):
             ('del', 'py_del'),                      ('js_del', 'del'),
             ('false', 'py_false'),
                                                     ('js_from', 'from'),
+                                                    ('js_global', 'global'),
             ('Infinity', 'py_Infinity'),            ('js_Infinity', 'Infinity'),
             ('isNaN', 'py_isNaN'),                  ('js_isNaN', 'isNaN'),
             ('iter', 'py_iter'),                    ('js_iter', 'iter'),


### PR DESCRIPTION
'global' is a valid symbol in JavaScript, but not python. Add 'js_global' as an alias to 'global' to allow for accessing this.