### PR TITLE
Fix zip function when zipping characters of a string with another list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 **.__pycache__/
 dist/
 transcrypt/docs/sphinx/_build/
-transcrypt.egg-info/
+*.egg-info/
 transcrypt/development/attic/
 transcrypt/development/docs/
 transcrypt/development/experiments/

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -555,8 +555,8 @@ __pragma__ ('endif')
     // Zip method for arrays and strings
     var zip = function () {
         var args = [] .slice.call (arguments);
-        if (typeof args [0] == 'string') {
-            for (var i = 0; i < args.length; i++) {
+        for (var i = 0; i < args.length; i++) {
+            if (typeof args [i] == 'string') {
                 args [i] = args [i] .split ('');
             }
         }


### PR DESCRIPTION
This pull request should fix an issue with zipping characters of a string with other lists, see #326 (second comment.)

The zip function was only checking if the first argument was a string and splitting it in that case. This meant that if the first argument was e.g. a list of integers and the second was the string 'abc', (as in the case of `enumerate('abc')`), the zip function didn't work. The patch splits all arguments to zip that are strings.

Includes a minor fix for .gitignore, where my `egg-info` was not being ignored by git.