### PR TITLE
Add tests for transcrypt module __future__

### DIFF
--- a/transcrypt/development/automated_tests/__future__/autotest.py
+++ b/transcrypt/development/automated_tests/__future__/autotest.py
@@ -1,0 +1,19 @@
+import division
+import generators
+import nested_scopes
+import print_function
+import unicode_literals
+# import with_statement
+
+from org.transcrypt.autotester import AutoTester
+
+atester = AutoTester()
+
+atester.run(division, 'division')
+atester.run(generators, 'generators')
+atester.run(nested_scopes, 'nested_scope')
+atester.run(print_function, 'print_function')
+atester.run(unicode_literals, 'unicode_literals')
+# atester.run(with_statement, 'with_statement')
+
+atester.done()

--- a/transcrypt/development/automated_tests/__future__/division.py
+++ b/transcrypt/development/automated_tests/__future__/division.py
@@ -1,0 +1,26 @@
+from __future__ import division
+
+def _check(x, test):
+    # Floats have different precision/representation in js and python
+    # Limit precision to 15 digits and convert to int if float is int
+    # See transcrypt/module_math for similar function
+
+    # 42.0 is 42
+    if x == int(x):
+        x = int(x)
+
+    # 15 first digits
+    if isinstance(x, float):
+        x = str(x)[:15]
+
+    test.check(x)
+
+def run(test):
+    check = lambda x: _check(x, test)
+
+    for i in range(1, 10):
+        check(42 / i)
+        check(i / 42)
+
+        check(42 // i)
+        check(i // 42)

--- a/transcrypt/development/automated_tests/__future__/generators.py
+++ b/transcrypt/development/automated_tests/__future__/generators.py
@@ -1,0 +1,5 @@
+from __future__ import generators
+
+def run(test):
+    for i in range(10):
+        test.check(i)

--- a/transcrypt/development/automated_tests/__future__/nested_scopes.py
+++ b/transcrypt/development/automated_tests/__future__/nested_scopes.py
@@ -1,0 +1,14 @@
+from __future__ import nested_scopes
+
+def run(test):
+
+    def foo():
+        x = 42
+
+        def bar():
+            test.check(x)
+
+        bar()
+
+    foo()
+    

--- a/transcrypt/development/automated_tests/__future__/print_function.py
+++ b/transcrypt/development/automated_tests/__future__/print_function.py
@@ -1,0 +1,4 @@
+from __future__ import print_function
+
+def run(test):
+    test.check("from __future__ import print_function works")

--- a/transcrypt/development/automated_tests/__future__/unicode_literals.py
+++ b/transcrypt/development/automated_tests/__future__/unicode_literals.py
@@ -1,0 +1,7 @@
+from __future__ import unicode_literals
+
+def run(test):
+    test.check('Hello, world!')
+    test.check(u'Hello, world!')
+    # TODO: byte strings are not supported?
+    # test.check(b'Hello, world!')

--- a/transcrypt/development/automated_tests/__future__/with_statement.py
+++ b/transcrypt/development/automated_tests/__future__/with_statement.py
@@ -1,0 +1,14 @@
+from __future__ import with_statement
+
+class SimpleWith:
+    def __enter__(self):
+        return 42
+
+    def __exit__(self, type, value, traceback):
+        pass
+
+def run(test):
+    with SimpleWith() as sw:
+        pass
+
+    test.check('ok')


### PR DESCRIPTION
Here are some promised tests for the `__future__` module that you merged earlier. (This PR message is a superset of the commit message). I am using the `0.13-dev` version of bottle (and still haven't figured out/don't want to figure out how to run two pythons in one virtual environment), so we will have to see if this tests pass CI on current `2.x` and `0.12.9` Travis (I've checked them locally on `0.13-dev` with `3.6.1` python)

The two things that I could not make to work in tests: byte strings with `b'Hello, world!` syntax and the `with` statement with the custom simple context manager. I left them commented out. Any thoughts?

Add simple tests for these features:
- division
- generators
- nested_scopes
- print_function
- unicode_literals

Tests that need attention:
- byte strings in unicode_literals
- with_statement (simple Context Manager does not work)

Tests that were not considered:
- absolute imports