### PR TITLE
Add inspect.isclass and tests for it

### DIFF
--- a/transcrypt/development/automated_tests/inspect/autotest.py
+++ b/transcrypt/development/automated_tests/inspect/autotest.py
@@ -1,0 +1,9 @@
+from org.transcrypt.autotester import AutoTester
+
+import test_isclass
+
+atester = AutoTester()
+
+atester.run(test_isclass, 'test_isclass')
+
+atester.done()

--- a/transcrypt/development/automated_tests/inspect/test_isclass.py
+++ b/transcrypt/development/automated_tests/inspect/test_isclass.py
@@ -1,0 +1,20 @@
+import inspect
+
+class SimpleClass:
+    pass
+
+def simple_function():
+    pass
+
+def run(test):
+    test.check(inspect.isclass(42))
+    test.check(inspect.isclass(42.0))
+    test.check(inspect.isclass('foo'))
+
+    simple_class = SimpleClass()
+    test.check(inspect.isclass(SimpleClass))
+    test.check(inspect.isclass(simple_class))
+    test.check(inspect.isclass(SimpleClass()))
+
+    test.check(inspect.isclass(simple_function))
+    test.check(inspect.isclass(simple_function()))

--- a/transcrypt/development/continuous_integration/set1
+++ b/transcrypt/development/continuous_integration/set1
@@ -1,5 +1,7 @@
 # These are run by travis and will cause build breaks if failing. Comment out via a '#', NOT VIA ''' ... '''!
+__future__
 hello
+inspect
 logging
 # re    # Somehow stalls with Python 3.6, shipment test runs Ok with it.
 time

--- a/transcrypt/modules/inspect/__init__.py
+++ b/transcrypt/modules/inspect/__init__.py
@@ -1,0 +1,3 @@
+def isclass(object):
+    """Return true if the object is a class."""
+    return hasattr(object, '__metaclass__') and not hasattr(object, '__class__')


### PR DESCRIPTION
Currently the javascript version returns `False` for everything (class, function or whatever) while python version, obviously, returns `False` for everything except a class, when in returns `True`. See test.

Any idea why `isclass` does not work?

Update: I copied its implementation [from cpython](https://github.com/python/cpython/blob/af5392f5c6f8014659e995840df6ee7b5017f743/Lib/inspect.py#L73).