### PR TITLE
Add some of the string methods:

### DIFF
--- a/transcrypt/development/automated_tests/transcrypt/module_builtin/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/module_builtin/__init__.py
@@ -103,4 +103,8 @@ def run (autoTester):
             canonizeStringList (aString.rsplit (',', 4)),
             '<br>'
         )
-        
+
+    autoTester.check("".isalpha())
+    autoTester.check("123".isalpha())
+    autoTester.check("abc".isalpha())
+    autoTester.check("abc123".isalpha())

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -1121,6 +1121,34 @@ __pragma__ ('endif')
         enumerable: true
     });
 
+    String.prototype.isalnum = function () {
+        return /^[0-9a-zA-Z]{1,}$/.test(this)
+    }
+
+    String.prototype.isalpha = function () {
+        return /^[a-zA-Z]{1,}$/.test(this)
+    }
+
+    String.prototype.isdecimal = function () {
+        return /^[0-9]{1,}$/.test(this)
+    }
+
+    String.prototype.isdigit = function () {
+        return this.isdecimal()
+    }
+
+    String.prototype.islower = function () {
+        return /^[a-z]{1,}$/.test(this)
+    }
+
+    String.prototype.isupper = function () {
+        return /^[A-Z]{1,}$/.test(this)
+    }
+
+    String.prototype.isspace = function () {
+        return /^[\s]{1,}$/.test(this)
+    }
+
     String.prototype.isnumeric = function () {
         return !isNaN (parseFloat (this)) && isFinite (this);
     };


### PR DESCRIPTION
 - isalnum
 - isalpha
 - isdecimal
 - isdigit
 - islower
 - isupper
 - isspace
 - isnumeric (*)

These methods are *not* entirely compatible with CPython because they
deal with ascii characters only, not general unicode. Also, isnumeric
existed before and it is even less compatible: it allows floats, which
python does not.

I have also tried adding some tests but it did not work for me:

I navigated to `automated_tests/transcrypt`, compiled the tests with these two commands:

```
transcrypt -c -da autotest.py
transcrypt -r -c -da autotest.py
```

After that, I opened `autotest.html` and it showed me an empty table.