### PR TITLE
Expand projectDir and suggest to drop programDir

### DIFF
--- a/transcrypt/__main__.py
+++ b/transcrypt/__main__.py
@@ -102,7 +102,7 @@ def main ():
         # Prepend paths that are needed by transpiled or executed user code, since they have to be searched first
         # So user code favors Transcrypt modules over CPython modules
         extraPath = utils.commandArgs.xpath.replace ('#', ' ') .split ('$') if utils.commandArgs.xpath else []
-        projectPath = [programDir] + extraPath
+        projectPath = [programDir, utils.commandArgs.source.rsplit('/', 1)[0]] + extraPath
         
         sys.path [0 : 0] = projectPath
         


### PR DESCRIPTION
For me `Transcrypt` is often run as part of a script that makes `Transcrypt` transpile files that are deeper than one level down in the directory, like so:

```
./bin/transcrypt ./dir0/dir1/file.py
```

Yet `__main__.py` relies on `sys.path.getcwd()` for `programDir` which is later propagated further and further until it is used as the directory where the file-to-be-transpiled (aka `file.py`) resides. The use-case above does not always work because of that. Instead, I would like to propose the reuse of `utils.commandArgs.source` which already points to the file that must be transpiled. I would also like to propose dropping `programDir`.