### PR TITLE
Make __t__ respect __bool__ and __len__ like Python does

### DIFF
--- a/transcrypt/development/automated_tests/transcrypt/truthyness/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/truthyness/__init__.py
@@ -112,5 +112,28 @@ def run (autoTester):
     class A:
         pass
         
+    class B:
+        def __bool__(self):
+            return False
+
+    class C:
+        def __bool__(self):
+            return True
+
+        def __len__(self):
+            return 0
+
+    class D:
+        def __len__(self):
+            return 0
+
+    class E:
+        def __len__(self):
+            return 1
+
+    autoTester.check ('instances of a custom class')
     autoTester.check (not not A ())
-    
+    autoTester.check (not not B ())
+    autoTester.check (not not C ())
+    autoTester.check (not not D ())
+    autoTester.check (not not E ())

--- a/transcrypt/development/automated_tests/transcrypt/truthyness/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/truthyness/__init__.py
@@ -113,27 +113,28 @@ def run (autoTester):
         pass
         
     class B:
-        def __bool__(self):
+        def __bool__ ( self):
             return False
 
     class C:
-        def __bool__(self):
+        def __bool__ (self):
             return True
 
-        def __len__(self):
+        def __len__ (self):
             return 0
 
     class D:
-        def __len__(self):
+        def __len__ (self):
             return 0
 
     class E:
-        def __len__(self):
+        def __len__ (self):
             return 1
 
-    autoTester.check ('instances of a custom class')
+    autoTester.check ('instances of custom classes')
     autoTester.check (not not A ())
     autoTester.check (not not B ())
     autoTester.check (not not C ())
     autoTester.check (not not D ())
     autoTester.check (not not E ())
+    

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -233,50 +233,31 @@ __pragma__ ('endif')
         return py_typeof (any) == dict ? any.py_keys () : any;
     }
 
-    // If the target object is somewhat true, return it. Otherwise return false.
-    // Try to follow python conventions of truthyness: __bool__, __len__, etc.
-    function __t__(target) {
-        // Take a quick shortcut if target is a simple type
-        if (target === undefined || target === null) {
-            return target
-        }
-
-        if (['boolean', 'number'].indexOf(typeof target) >= 0) {
-            return target
-        }
-
-        // Use __bool__ (if present) to decide if target is true
-        if (target.__bool__ instanceof Function) {
-            if (target.__bool__()) {
-                return target
-            } else {
-                return false
-            }
-        }
-
-        // There is no __bool__, use __len__ (if present) instead
-        if (target.__len__ instanceof Function) {
-            if (target.__len__() !== 0) {
-                return target
-            } else {
-                return false
-            }
-        }
-
-        // There is no __bool__ and no __len__, declare Functions true.
-        // Python objects are transpiled into instances of Function and if
-        // there is no __bool__ or __len__, the object in Python is true.
-        if (target instanceof Function) {
-            return target
-        }
-
-        // Target is something else, compute its len to decide
-        if (len(target) !== 0) {
-            return target
-        }
-
-        // When all else fails, declare target as false
-        return false
+    function __t__ (target) { 
+        return (
+            // Avoid invalid checks
+            target === undefined || target === null ? false :
+            
+            // Take a quick shortcut if target is a simple type
+            ['boolean', 'number'] .indexOf (typeof target) >= 0 ? target :
+            
+            // Use __bool__ (if present) to decide if target is true
+            target.__bool__ instanceof Function ? (target.__bool__ () ? target : false) :
+            
+            // There is no __bool__, use __len__ (if present) instead
+            target.__len__ instanceof Function ?  (target.__len__ () !== 0 ? target : false) :
+            
+            // There is no __bool__ and no __len__, declare Functions true.
+            // Python objects are transpiled into instances of Function and if
+            // there is no __bool__ or __len__, the object in Python is true.
+            target instanceof Function ? target :
+            
+            // Target is something else, compute its len to decide
+            len (target) !== 0 ? target :
+            
+            // When all else fails, declare target as false
+            false
+        );
     }
     __all__.__t__ = __t__;
 

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -237,6 +237,10 @@ __pragma__ ('endif')
     // Try to follow python conventions of truthyness: __bool__, __len__, etc.
     function __t__(target) {
         // Take a quick shortcut if target is a simple type
+        if (target === undefined || target === null) {
+            return target
+        }
+
         if (['boolean', 'number'].indexOf(typeof target) >= 0) {
             return target
         }


### PR DESCRIPTION
This improves compatibility and allows more fine-grained truth-value
testing control for python classes.

Closes #375 

There are more tests and the old tests pass locally, let's look at what CI has to say.

Update: and CI passes, bingo!