### PR TITLE
Make function len call __len__ (from Python) if it exists

### DIFF
--- a/transcrypt/development/automated_tests/transcrypt/general_functions/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/general_functions/__init__.py
@@ -10,7 +10,30 @@ class B (A):
     def __init__ (self):
         self.foo4 = 'bar4'
         
+class C:
+    def __len__ (self):
+        return 42
+
 def run (autoTester):
+    autoTester.check ('len')
+
+    strings = ['hello', ',', 'world', '!']
+    instances = [C()]
+    collections = [
+        [], [1], [1, 2],
+        tuple(), (1,), (1, 2),
+        {}, {1: 1}, {1: 1, 2: 2}
+    ]
+
+    for string in strings:
+        autoTester.check (len (string))
+
+    for instance in instances:
+        autoTester.check (len (instance))
+
+    for collection in collections:
+        autoTester.check (len (collection))
+
     autoTester.check ('sort and sorted<br>')
     a = [1, 5, 3, 2, -1]
     b = ['sun', 'earth', 'moon']

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -207,25 +207,25 @@ __pragma__ ('endif')
     // Compute length of any object
     var len = function (anObject) {
         if (anObject === undefined || anObject === null) {
-            return 0
+            return 0;
         }
 
         if (anObject.__len__ instanceof Function) {
-            return anObject.__len__()
+            return anObject.__len__ ();
         }
 
         if (anObject.length !== undefined) {
-            return anObject.length
+            return anObject.length;
         }
 
-        var length = 0
+        var length = 0;
         for (var attr in anObject) {
-            if (!__specialattrib__(attr)) {
-                length++
+            if (!__specialattrib__ (attr)) {
+                length++;
             }
         }
 
-        return length
+        return length;
     };
     __all__.len = len;
 

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -204,26 +204,28 @@ __pragma__ ('endif')
     };
     __all__.__specialattrib__ = __specialattrib__;
 
-    // Len function for any object
+    // Compute length of any object
     var len = function (anObject) {
-        if (anObject) {
-            var l = anObject.length;
-            if (l == undefined) {
-                var result = 0;
-                for (var attrib in anObject) {
-                    if (!__specialattrib__ (attrib)) {
-                        result++;
-                    }
-                }
-                return result;
-            }
-            else {
-                return l;
+        if (anObject === undefined || anObject === null) {
+            return 0
+        }
+
+        if (anObject.__len__ instanceof Function) {
+            return anObject.__len__()
+        }
+
+        if (anObject.length !== undefined) {
+            return anObject.length
+        }
+
+        var length = 0
+        for (var attr in anObject) {
+            if (!__specialattrib__(attr)) {
+                length++
             }
         }
-        else {
-            return 0;
-        }
+
+        return length
     };
     __all__.len = len;
 


### PR DESCRIPTION
I've also added a couple of tests for the `len` function. Notably, it is still rather different from the `len` in Python: it does not throw errors for things that "do not have a length", like numbers, `None` or whatever. However, such fine-grained compatibility is not necessary. What is necessary, in my opinion, is to use `__len__` when the object has it.