### PR TITLE
Remove default messages for ValueError and KeyError

### DIFF
--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -286,7 +286,7 @@ __pragma__ ('endif')
                 return 1;
             }
             else {  // Needed e.g. in autoTester.check, so "return any ? true : false" won't do
-                throw ValueError (new Error ());
+                throw ValueError ("could not convert string to float: '" + str(any) + "'", new Error ());
             }
         }
         else {
@@ -843,7 +843,7 @@ __pragma__ ('endif')
     Array.prototype.remove = function (element) {
         var index = this.indexOf (element);
         if (index == -1) {
-            throw ValueError (new Error ());
+            throw ValueError ("list.remove(x): x not in list", new Error ());
         }
         this.splice (index, 1);
     };
@@ -1346,7 +1346,7 @@ __pragma__ ('endif')
     function __popitem__ () {
         var aKey = Object.keys (this) [0];
         if (aKey == null) {
-            throw KeyError (aKey, new Error ());
+            throw KeyError ("popitem(): dictionary is empty", new Error ());
         }
         var result = tuple ([aKey, this [aKey]]);
         delete this [aKey];

--- a/transcrypt/modules/org/transcrypt/__standard__.py
+++ b/transcrypt/modules/org/transcrypt/__standard__.py
@@ -42,13 +42,13 @@ class StopIteration (Exception):
     def __init__ (self, error):
         Exception.__init__ (self, 'Iterator exhausted', error = error)
         
-class ValueError (Exception,):
-    def __init__ (self, error):
-        Exception.__init__ (self, 'Erroneous value', error = error)
+class ValueError (Exception):
+    def __init__ (self, message, error):
+        Exception.__init__ (self, message, error = error)
     
-class KeyError (Exception,):
-    def __init__ (self, error):
-        Exception.__init__ (self, 'Invalid key', error = error)
+class KeyError (Exception):
+    def __init__ (self, message, error):
+        Exception.__init__ (self, message, error = error)
     
 class AssertionError (Exception):
     def __init__ (self, message, error):


### PR DESCRIPTION
I believe this better matches Python's default behavior. 

This commit removes default `"Erroneous Value"` and `"Invalid Key"` messages for `ValueError` and `KeyError` respectively. These do not match Python's behavior, and prevent more custom messages from being passed in.

This commit also updates usages of ValueError and KeyError in `__builtin__` to use individual strings which match python3.5's error messages rather than using the defaults that are now removed.

I don't know if any end-user code relies on these messages, but this could be changed to keep `"Erroneous Value"` and `"Invalid Key"` messages as default if none are supplied. I chose to have `""` as the default message in order to match Python 3.5's behavior, but that's not as essentially useful as allowing customizable messages in the first place.

I see the messages were introduced in https://github.com/QQuick/Transcrypt/commit/9924f308b3711602ac282f1761c38d3487f3b84a#diff-493186bca6f730b8f74b3c21e15ab988, but I don't know the significance of `"Erroneous Value"` and `"Invalid Key"` here. If these messages do carry weight, I would definitely like to know.

The new code for `ValueError` and `KeyError` accepts an optional `'message'`, similar to what Exception itself accepts. The default string representation for a new `ValueError()` is now `""` (to match `ValueError()`'s message in Python3.5).

See #394.