### PR TITLE
example support for lexical operator overloading mode

### DIFF
--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -2515,7 +2515,7 @@ __pragma__ ('ifndef', '__xtiny__')
     
 __pragma__ ('endif')
 
-__pragma__ ('ifndef', '__xtiny__')
+__pragma__ ('ifdef', '__fopov__')
 
     // support for fast operator overload on numeric types
 

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -2515,7 +2515,7 @@ __pragma__ ('ifndef', '__xtiny__')
     
 __pragma__ ('endif')
 
-__pragma__ ('ifndef', 'xtratiny')
+__pragma__ ('ifndef', '__xtiny__')
 
     // support for fast operator overload on numeric types
 

--- a/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
+++ b/transcrypt/modules/org/transcrypt/__javascript__/__builtin__.mod.js
@@ -2458,7 +2458,7 @@ __pragma__ ('ifndef', '__xtiny__')
         }
     };
     __all__.__iand__ = __iand__;
-    
+
     // Indices and slices
 
     var __getitem__ = function (container, key) {                           // Slice c.q. index, direct generated call to runtime switch
@@ -2513,4 +2513,21 @@ __pragma__ ('ifndef', '__xtiny__')
     };
     __all__.__setslice__ = __setslice__;
     
+__pragma__ ('endif')
+
+__pragma__ ('ifndef', 'xtratiny')
+
+    // support for fast operator overload on numeric types
+
+    Number.prototype.__add__ = function(b) { return this.valueOf() + b; };
+    Number.prototype.__sub__ = function(b) { return this.valueOf() - b; };
+    Number.prototype.__mult__ = function(b) { return this.valueOf() * b; };
+    Number.prototype.__div__ = function(b) { return this.valueOf() / b;  };
+    Number.prototype.__lshift__= function(b){ return this.valueOf() << b; };
+    Number.prototype.__rshift__= function(b ){ return this.valueOf() >> b; };
+    Number.prototype.__or__ = function(b) { return this.valueOf() | b; };
+    Number.prototype.__xor__ = function(b) { return this.valueOf() ^ b; };
+    Number.prototype.__and__ = function(b) { return this.valueOf() & b; };
+    Number.prototype.__pow__ = function(b) { return this.valueOf() ** b; };
+
 __pragma__ ('endif')

--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -1753,12 +1753,17 @@ class Generator (ast.NodeVisitor):
                     self.allowKeywordArgs = False
 
                 elif node.args [0] .s == 'opov':        # Overloading of a small sane subset of operators allowed
-                    if len(node.args) == 2 and node.args[1]:
-                        self.allowFastOverloading = True
+                    self.allowFastOverloading = node.args [-1] .s == 'fast'
                     self.allowOperatorOverloading = True
                 elif node.args [0] .s == 'noopov':      # Operloading of a small sane subset of operators disallowed
                     self.allowOperatorOverloading = False
                     self.allowFastOverloading = False
+                elif node.args [0] .s == 'fopov':
+                    self.allowFastOverloading = True
+                    self.allowOperatorOverloading = True
+                elif node.args [0] .s == 'nofopov':
+                    self.allowFastOverloading = False
+                    self.allowOperatorOverloading = False
                 elif node.args [0] .s == 'redirect':
                     if node.args [1] .s == 'stdout':
                         self.emit ('__stdout__ = \'{}\'', node.args [2])

--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -129,18 +129,8 @@ class Overloads:
         return type(op) in cls.AST_OVERLOADS
 
     @classmethod
-    def unary(cls, op):
+    def get(cls, op):
         nodename = cls.AST_OVERLOADS.get(type(op))
-        if not nodename:
-            print ("Unsupported node type", op)
-        return "__i{}__".format(nodename)
-
-
-    @classmethod
-    def binary(cls, op):
-        nodename = cls.AST_OVERLOADS.get(type(op))
-        if not nodename:
-            print ("Unsupported node type", op)
         return "__{}__".format(nodename)
 
 
@@ -1379,9 +1369,12 @@ class Generator (ast.NodeVisitor):
         # fast overloading merely substitutes the python overload methods
         # and bypasses __call__
         if self.allowFastOverloading and Overloads.supported(node.op):
+            self.emit("var ")
+            self.visit(node.target)
+            self.emit(" = ")
             self.visit(node.target)
             self.emit(".")
-            self.emit(Overloads.unary(node.op))
+            self.emit(Overloads.get(node.op))
             self.emit("(")
             self.visit(node.value)
             self.emit(")")
@@ -1499,7 +1492,7 @@ class Generator (ast.NodeVisitor):
         elif self.allowFastOverloading and Overloads.supported(node.op):
             self.visit(node.left)
             self.emit(".")
-            self.emit(Overloads.binary(node.op))
+            self.emit(Overloads.get(node.op))
             self.emit("(")
             self.visit(node.right)
             self.emit(")")


### PR DESCRIPTION
A possible method for avoiding the overhead of `__call__` on overloaded operators.  Adds an optional argument that does a compile-time swap for the pythonic overload methods instead of the full call search.  So where this python:

    __pragma___('opov')
   a += b
   __ pragma__ ('noopov')

generates this JS:

     	var a= __call__ (__iadd__, null, a, b);

with the change this version:

    __pragma___('opov', 'fast')
   a += b
   __ pragma__ ('noopov')

generates
    
    a.__iadd__(b)

The intent would be to use this fairly narrowly in performance sensitive code.  

As written the following would fail if the left-hand operand does not have the correct magic methods.  For user code (especially pythong) that seems fine; it's an annoyance for native types.   However adding the magic methods to `Number.prototype` works, although I did not include it here because I was not sure where it would best be shimmed in