### PR TITLE
Do not use shlex.split under Windows

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -1678,7 +1678,9 @@ class Generator (ast.NodeVisitor):
                             if keyword.arg == 'cwd':
                                 workDir = keyword.value.s
                         process = subprocess.Popen (
-                            shlex.split(node.args [1] .s),
+                            # Do not use shlex.split under Windows
+                            node.args [1] .s if sys.platform == 'win32' else \
+                                shlex.split(node.args [1] .s),
                             stdin = subprocess.PIPE,
                             stdout = subprocess.PIPE,
                             cwd = workDir


### PR DESCRIPTION
The xtrans pragma currently uses subprocess/shlex for running external transpilers.

Using shlex.split for subprocess under Windows is broken.
Luckily, it is also not necessary in that case.
https://stackoverflow.com/a/35900070