### PR TITLE
Command line switch to define the shell command to be used in xtrans calls.

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -1677,10 +1677,13 @@ class Generator (ast.NodeVisitor):
                         for keyword in node.keywords:
                             if keyword.arg == 'cwd':
                                 workDir = keyword.value.s
+                        # Use xtrans command switch if given
+                        switch = utils.commandArgs.xtrans
+                        command = switch if switch else node.args [1] .s
                         process = subprocess.Popen (
                             # Do not use shlex.split under Windows
-                            node.args [1] .s if sys.platform == 'win32' else \
-                                shlex.split(node.args [1] .s),
+                            command if sys.platform == 'win32' else \
+                                shlex.split(command),
                             stdin = subprocess.PIPE,
                             stdout = subprocess.PIPE,
                             cwd = workDir

--- a/transcrypt/modules/org/transcrypt/utils.py
+++ b/transcrypt/modules/org/transcrypt/utils.py
@@ -63,6 +63,7 @@ class CommandArgs:
         self.argParser.add_argument ('-xc', '--xconfimp', help = "confine imported names to directly importing module", action = 'store_true')
         self.argParser.add_argument ('-xp', '--xpath', nargs = '?', help = "additional module search paths, joined by $, #'s will be replaced by spaces")
         self.argParser.add_argument ('-xt', '--xtiny', help = "generate tiny version of runtime, a.o. lacking support for implicit and explicit operator overloading. Use only if generated code can be validated, since it will introduce semantic alterations in edge cases", action = 'store_true')
+        self.argParser.add_argument ('-xx', '--xtrans', nargs='?', help = "Define the shell command to be used in xtrans calls, rather than defining it in the call each time.")
         self.argParser.add_argument ('-*', '--star', help = "Like it? Grow it! Go to GitHub and then click [* Star]", action = 'store_true')
         
         self.__dict__.update (self.argParser.parse_args () .__dict__)


### PR DESCRIPTION
A command line switch can be used rather than defining it in the call each time.
Resolves issue #506 