### PR TITLE
Implement a builtin alias of 'js_default' -> 'default'

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -645,7 +645,7 @@ class Generator (ast.NodeVisitor):
             ('case', 'py_case'),
             ('clear', 'py_clear'),                  ('js_clear', 'clear'),
                                                     ('js_conjugate', 'conjugate'),
-            ('default', 'py_default'),
+            ('default', 'py_default'),              ('js_default', 'default'),
             ('del', 'py_del'),                      ('js_del', 'del'),
             ('false', 'py_false'),
                                                     ('js_from', 'from'),


### PR DESCRIPTION
Fixes issue: https://github.com/QQuick/Transcrypt/issues/514