### PR TITLE
Add support for reading aliases from textfiles

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -183,6 +183,21 @@ class Program:
         self.loaderTargetPath = '{}/{}.js'.format (self.targetDir, self.loaderName)
         self.loaderMiniTargetPath = '{}/{}.min.js'.format (self.targetDir, self.loaderName)
 
+        # store a global file(s), if provided on the commandline
+        self.file_aliases = {}
+        if utils.commandArgs.aliasfile:
+            for af in utils.commandArgs.aliasfile:
+                found = False
+                for each_dir in self.moduleSearchDirs:
+                    if not found:
+                        alias_file =  '/'.join((each_dir, af))
+                        if os.path.exists(alias_file):
+                            alias_dict = utils.read_alias_file(alias_file)
+                            self.file_aliases[af] = alias_dict
+                            found = True
+                if not found:
+                    raise FileNotFoundError("alias file '{0}' not found, check project and module paths in {1}".format(af, self.moduleSearchDirs))
+
         # Compile inline modules
         if not ('__cunit__' in self.symbols):
             Module (self, ModuleMetadata (self, self.coreModuleName), True)
@@ -1637,15 +1652,37 @@ class Generator (ast.NodeVisitor):
                 return
             elif node.func.id == '__pragma__':
                 if node.args [0] .s == 'alias':
-                    self.aliasers.insert (0, self.getAliaser (node.args [1] .s, node.args [2].s))
+                    if len(node.args) == 2:
+                        # single argument us a key to into the global aliases loaded from file
+
+                        alias_dict = self.module.program.file_aliases.get(node.args [1] .s)
+                        
+                        if not alias_dict:
+                            raise utils.Error (
+                                lineNr = self.lineNr,
+                                message = "unknown alias file: '{0}'.  Alias files must be provided on the command line".format(node.args [1] .s)
+                                )
+                        else:
+                            for py_id, js_id in alias_dict.items():
+                                self.aliasers.insert (0, self.getAliaser (py_id, js_id))
+                    else:
+                        if node.args [1] .s in self.module.program.file_aliases:
+                            raise utils.Error (
+                                lineNr = self.lineNr,
+                                message = "alias identifier conflicts with alias file name: {0}".format(node.args [1] .s)
+                                )
+                        self.aliasers.insert (0, self.getAliaser (node.args [1] .s, node.args [2].s))
                 elif node.args [0] .s == 'noalias':
                     if len (node.args) == 1:
                         self.aliasers = []
                     else:
+                        # note: if there's a collision between a single-item alias and a file alias,
+                        # the file alias will win -- hence the compile error above
+                        alias_dict = self.module.program.file_aliases.get(node.args [1] .s,  {node.args [1] . s})
                         for index in reversed (range (len (self.aliasers))):
-                            if self.aliasers [index][0] == node.args [1] .s:
+                            if self.aliasers [index][0] in alias_dict:
                                 self.aliasers.pop (index)
-
+                
                 elif node.args [0] .s == 'noanno':
                     self.allowDebugMap = False
 

--- a/transcrypt/modules/org/transcrypt/utils.py
+++ b/transcrypt/modules/org/transcrypt/utils.py
@@ -29,6 +29,8 @@ class CommandArgs:
         
         self.argParser.add_argument ('source', nargs='?', help = ".py file containing source code of main module")
         self.argParser.add_argument ('-a', '--anno', help = "annotate target files that were compiled from Python with source file names and source line numbers", action = 'store_true')
+        self.argParser.add_argument('-af', '--aliasfile', nargs = "?", help = "include predefined aliases for the alias pragma", action="append" )
+
         self.argParser.add_argument ('-b', '--build', help = "rebuild all target files from scratch", action = 'store_true')
         self.argParser.add_argument ('-c', '--complex', help = "enable complex number support, locally requires operator overloading", action = 'store_true')
         self.argParser.add_argument ('-d', '--docat', help = "enable __doc__ attributes. Apply sparsely, since it will make docstrings part of the generated code", action = 'store_true')
@@ -65,6 +67,7 @@ class CommandArgs:
         self.argParser.add_argument ('-xt', '--xtiny', help = "generate tiny version of runtime, a.o. lacking support for implicit and explicit operator overloading. Use only if generated code can be validated, since it will introduce semantic alterations in edge cases", action = 'store_true')
         self.argParser.add_argument ('-xtr', '--xtrans', nargs = '?', help = "Define the shell command to be used for external translation, rather than defining it in the xtrans pragma each time.")
         self.argParser.add_argument ('-*', '--star', help = "Like it? Grow it! Go to GitHub and then click [* Star]", action = 'store_true')
+
         
         self.__dict__.update (self.argParser.parse_args () .__dict__)
         
@@ -171,3 +174,14 @@ def enhanceException (exception, **kwargs):
 
     raise result
     
+
+def read_alias_file(filename):
+    """parses a tab or space separated file of aliases"""
+    with open(filename, 'rt') as filehandle:
+        alias_dict = {}
+        for line in filehandle:
+            if not line.startswith("#"):
+                tokens = line.split()
+                if len(tokens) == 2:
+                    alias_dict[tokens[0]] = tokens[1]
+    return alias_dict


### PR DESCRIPTION
I've found that I sometimes want to do a pep-8-ificiation on an external JS library so my code is consistent  from end to end, but managing the large number of aliases involved manually is very hairy.

This allows the user to specify one or more alias files from the compiler command line, and activate/deactivate them using the alias pragma.  A single-argument pragma is assumed to be a file name when adding aliases, and for noalias specifying the file name again removes all aliases which emanate from it.


      __pragma___('alias', 'myaliasfile')

      item.this_is_an_alias ("defined in myaliasfile")

     __pragma__('noalias', 'mayaliasfile') 

Alias files can live anywhere on the module search path.

I've found this convenient, though it would be particularly nice to make the aliases part of the module mechanism when the new module code comes on line -- that would allow module authors to provide a degree of 'pythonicity' with their modules for purists who want to opt in to it.  '

Since it's all jus the existing Transcrypt aliases with a little helper scaffolding it has no runtime perf implications.