### PR TITLE
[WIP] Add unicodedata.normalize()

### DIFF
--- a/transcrypt/modules/unicodedata/__init__.py
+++ b/transcrypt/modules/unicodedata/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+def normalize(form, unistr):
+    # Delegate to ES6's method:
+    # http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.normalize
+    # Both ES6 and CPython require that `form` be the same four values.
+    # https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Modules/unicodedata.c
+    return String.prototype.normalize.call(unistr, form)


### PR DESCRIPTION
Let me know if there's a way I can add automated tests for this module!

Here's a simple test for this function:

```python
from unicodedata import normalize

# '\u00e8' == 'é'
# '\u0301' == 'e' + '\N{COMBINING ACUTE ACCENT}'
assert normalize('NFC', '\u00e9') == normalize('NFC', 'e\u0301'))
```

Addresses #547 