### PR TITLE
Explicitly open autotest.html in UTF-8.

### DIFF
--- a/transcrypt/modules/org/transcrypt/autotester/html.py
+++ b/transcrypt/modules/org/transcrypt/autotester/html.py
@@ -73,8 +73,8 @@ class HTMLGenerator(object):
         
         jsPath = f'__target__/{self._fnameBase.split ("/")[-1]}.js'
 
-        with open( fname, 'w') as f:
-            f.write("<html><head>")
+        with open( fname, 'w', encoding='UTF-8') as f:
+            f.write("<html><head><meta charset='UTF-8'>")
             self._writeCSS(f)
             f.write("</head><body>")
 


### PR DESCRIPTION
Should address trying to run autotest on systems where the default encoding is *not* UTF-8.