### PR TITLE
Use JavaScript Array.slice in '__getslice__' when applicable

### DIFF
--- a/transcrypt/modules/org/transcrypt/__builtin__.js
+++ b/transcrypt/modules/org/transcrypt/__builtin__.js
@@ -980,6 +980,10 @@ Array.prototype.__getslice__ = function (start, stop, step) {
         stop = this.length;
     }
 
+    if (step == 1) {
+        return Array.prototype.slice.call(this, start, stop);
+    }
+
     let result = list ([]);
     for (let index = start; index < stop; index += step) {
         result.push (this [index]);


### PR DESCRIPTION
For step=1, the common case, performing a native array slice should be faster than copying the elements ourselves.

I'm not sure how to profile to tell whether it actually is, but it seems like it could be a good idea.

Let me know what you think, and whether there's anything else I can do in this PR. I'm not 100% familiar with the structure nowadays and I'm not sure whether anything needs to be done for pre-ES6 compatibility here?