### PR TITLE
Remove generation of 'list()' around list literals

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -2837,11 +2837,11 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
         self.emit (';\n}})')
 
     def visit_List (self, node):
-        self.emit ('list ([')
+        self.emit ('[')
         for index, elt in enumerate (node.elts):
             self.emitComma (index)
             self.visit (elt)
-        self.emit ('])')
+        self.emit (']')
 
     def visit_ListComp (self, node, isSet = False, isDict = False, isGenExp = False):
         elts = []


### PR DESCRIPTION
This should be purely a output-code-niceness improvement.

`list()` currently just runs `Array.from`, so it seems redundant if we've already just created a fresh list using `[]` syntax. I don't believe it will have any affect other than just having another function run every time a list is instantiated.