### PR TITLE
Create an error to get a stacktrace if an error isn't passed into Exception.__init__

### DIFF
--- a/transcrypt/modules/org/transcrypt/__runtime__.py
+++ b/transcrypt/modules/org/transcrypt/__runtime__.py
@@ -21,6 +21,8 @@ class Exception (BaseException):
         self.__args__ = args
         if kwargs.error != None:
             self.stack = kwargs.error.stack # Integrate with JavaScript Error object
+        elif Error:
+            self.stack = (__new__(Error())).stack # Create our own stack if we aren't given one
         else:
             self.stack = 'No stack trace available'
     #__pragma__ ('nokwargs')

--- a/transcrypt/modules/org/transcrypt/__runtime__.py
+++ b/transcrypt/modules/org/transcrypt/__runtime__.py
@@ -19,9 +19,9 @@ class Exception (BaseException):
     #__pragma__ ('kwargs')
     def __init__ (self, *args, **kwargs):
         self.__args__ = args
-        try:
+        if kwargs.error != None:
             self.stack = kwargs.error.stack # Integrate with JavaScript Error object
-        except:
+        else:
             self.stack = 'No stack trace available'
     #__pragma__ ('nokwargs')
         


### PR DESCRIPTION
Not 100% sure this is a change that wants to be made, but opening this PR just in case.

This should let all errors that inherit from `Exception` have stack traces, even if no error is passed into the constructor. The stack traces will be a bit longer since they'll include `Exception.__init__` itself, but I think they should still be useful?

This is just another change I was working with that I'm not 100% sure if it makes sense to make in transcrypt itself.