### PR TITLE
Make int() function match python's int() more fully

### DIFF
--- a/transcrypt/modules/org/transcrypt/__builtin__.js
+++ b/transcrypt/modules/org/transcrypt/__builtin__.js
@@ -288,8 +288,21 @@ export function float (any) {
 float.__name__ = 'float';
 float.__bases__ = [object];
 
-export function int (any) {
-    return float (any) | 0
+export function int (any, radix) {
+    if (any === false) {
+        return 0;
+    } else if (any === true) {
+        return 1;
+    } else {
+        var number = parseInt(any, radix);
+        if (isNaN (number)) {
+            if (radix == undefined) {
+                radix = 10;
+            }
+            throw ValueError('invalid literal for int() with base ' + radix + ': ' + any, new Error());
+        }
+        return number;
+    }
 };
 int.__name__ = 'int';
 int.__bases__ = [object];


### PR DESCRIPTION
Currently, Transcrypt's `int` allows float values and `int(4.4) = 4.4` (whereas `int(4.4)` in Python is `4`). Additionally, Python `int` supports an additional 'base' argument which is not supported in Transcrypt.

This should fix those two issues. However, it does mean a bit of duplication between `int` and `float` which I'm not sure how to remove.

This also tries to match python's behavior much more exactly, which might or might not be what we want. At minimum it would be nice if `int()` did floor values, but if we didn't want to support the rest this could just be `Math.floor (float (any))` rather than this whole deal.