### PR TITLE
Empty exportedNames generated

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -2861,6 +2861,7 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
                     try:                                                        # Try if alias.name denotes a module
                         module = self.useModule ('{}.{}'.format (node.module, alias.name))
                         self.emit ('import * as {} from \'{}\';\n', self.filterId (alias.asname) if alias.asname else self.filterId (alias.name), module.importRelPath)
+                        self.allImportedNames.add(alias.asname or alias.name)   # add import to allImportedNames of this module
                     except:                                                     # If it doesn't it denotes a facility inside a module
                         module = self.useModule (node.module)
                         namePairs.append (utils.Any (name = alias.name, asName = alias.asname))      

--- a/transcrypt/modules/org/transcrypt/utils.py
+++ b/transcrypt/modules/org/transcrypt/utils.py
@@ -297,7 +297,7 @@ def digestJavascript (code, symbols, mayStripComments, mayRemoveAnnotations, ref
     
     namesPattern = re.compile ('({.*})')
     pathPattern = re.compile ('([\'|\"].*[\'|\"])')
-    wordPattern = re.compile (r'\w+')
+    wordPattern = re.compile (r'[a-zA-Z_]\w*')
     for line in passableLines:
         words = wordPattern.findall (line)
         
@@ -308,7 +308,7 @@ def digestJavascript (code, symbols, mayStripComments, mayRemoveAnnotations, ref
             if words [0] == 'export':
                 # Deducing exported names from JavaScript is needed to facilitate * import by other modules
                 
-                if words [1] in {'var', 'function'}:
+                if words [1] in ['var', 'function']:
                     # Export prefix:    "export var ... or export function ..."
                     
                     result.exportedNames.append (words [2])


### PR DESCRIPTION
Hello Jaques,

in my project I had the problem that the JavaScripts generated by Transcrypt didn't work due to missing symbols, which where not imported (in this case from the runtimeModule).

This is what my generated code looked like before this bugfix:
```javascript
/* 000001 */ import {} from './org.transcrypt.__runtime__.js';
```

I then found out, that the exportedNames member of the `utils.digestJavascript()` (which is also called multiple times on the same module, but that's another story) was empty under some circumstances. 

Following the bug deeper, I found out that exportedNames was not filled when the lines begin with a line number comment, like `/* 000123 */`, which is the case in my project.

The regular expression `wordPattern` is defined as `\w+` and therefore also recognizes these line numbers as first word, resulting in that the loop below doesn't find any lines beginning with var or function to build the exportedNames list.

Now the correctly generated code looks like this:
```javascript
/* 000001 */ import {AssertionError, AttributeError, BaseException, DeprecationWarning, Exception, IndexError, IterableError, KeyError, NotImplementedError, RuntimeWarning, StopIteration, UserWarning, ValueError, Warning, __JsIterator__, __PyIterator__, __Terminal__, __add__, __and__, __call__, __class__, __envir__, __eq__, __floordiv__, __ge__, __get__, __getcm__, __getitem__, __getslice__, __getsm__, __gt__, __i__, __iadd__, __iand__, __idiv__, __ijsmod__, __ilshift__, __imatmul__, __imod__, __imul__, __in__, __init__, __ior__, __ipow__, __irshift__, __isub__, __ixor__, __jsUsePyNext__, __jsmod__, __k__, __kwargtrans__, __le__, __lshift__, __lt__, __matmul__, __mergefields__, __mergekwargtrans__, __mod__, __mul__, __ne__, __neg__, __nest__, __or__, __pow__, __pragma__, __proxy__, __pyUseJsNext__, __rshift__, __setitem__, __setproperty__, __setslice__, __sort__, __specialattrib__, __sub__, __super__, __t__, __terminal__, __truediv__, __withblock__, __xor__, abs, all, any, assert, bool, bytearray, bytes, callable, chr, copy, deepcopy, delattr, dict, dir, divmod, enumerate, filter, float, getattr, hasattr, input, int, isinstance, issubclass, len, list, map, max, min, object, ord, pow, print, property, py_TypeError, py_iter, py_metatype, py_next, py_reversed, py_typeof, range, repr, round, set, setattr, sorted, str, sum, tuple, zip} from './org.transcrypt.__runtime__.js';
```

This pull request fixes this issue for now, but please feel free to fix it differently. Generally, I thought if it wouldn't be better to use a real JavaScript parser in this case to examine Javascript modules and their exported names rather than the current, line-based solution? If you are interested, we can discuss about it and I may provide more code on this.

Best regards,

Jan