### PR TITLE
Extend allImportedNames to simple from...import statements

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -2861,6 +2861,7 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
                     try:                                                        # Try if alias.name denotes a module
                         module = self.useModule ('{}.{}'.format (node.module, alias.name))
                         self.emit ('import * as {} from \'{}\';\n', self.filterId (alias.asname) if alias.asname else self.filterId (alias.name), module.importRelPath)
+                        self.allImportedNames.add(alias.asname or alias.name)   # add import to allImportedNames of this module
                     except:                                                     # If it doesn't it denotes a facility inside a module
                         module = self.useModule (node.module)
                         namePairs.append (utils.Any (name = alias.name, asName = alias.asname))      


### PR DESCRIPTION
Hi Jacques,

I've got the following, simple __init__.py in my library called `html5`:

```python
from html5.html5 import *
from html5 import ext
```

The current transcrypt master eats it, but only exports the names from `html5.html5`, not the `html5.ext`.

This was the faulty code before this fix:

```javascript
/* 000004 */ import * as ext from './html5.ext.js';
/* 000003 */ import {A, Abbr, Address, Area, Article, Aside, Audio...} from './html5.html5.js';
/* 000003 */ export {A, Abbr, Address, Area, Article, Aside, Audio...};
```

Now it is:
```javascript
/* 000004 */ import * as ext from './html5.ext.js';
/* 000003 */ import {A, Abbr, Address, Area, Article, Aside, Audio...} from './html5.html5.js';
/* 000003 */ export {ext, A, Abbr, Address, Area, Article, Aside, Audio...};
```

This pull requests fixes it for now and adds `ext` also to the allImportedNames set of the module.
Is this okay?