### PR TITLE
[WIP] __pragma__ as context manager

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -3474,6 +3474,10 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
 
         @contextmanager
         def itemContext (item):
+            if not self.noskipCodeGeneration:
+                yield
+                return
+
             self.emit ('var ')                      # Should be in surrounding scope but may be overwritten, so use var rather than let
             if (item.optional_vars):
                 self.visit (item.optional_vars)


### PR DESCRIPTION
Preliminary implementation of #552, placed here to get some feedback.

I've managed to make it work for the most of the pragmas, including 'skip' and 'alias'. The `__exit__` part of the `with` statement is implemented by prefixing `no` to the name of pragma (or removing it) for now, which should work well in most cases, but it will not always restore the flags to the same state they were before `with`. There is various ways to go about this problem.

I think, the simplest solution would be to write a pair of push/pop methods (and push/pop pragmas, probably) to save and restore all flags at once and use them before and after with-clause. This will have side effect of creating a scope for pragmas inside each with-clause, but the effect is probably not undesired.
