### PR TITLE
Add command-line flag for output directory

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -74,7 +74,11 @@ class Program:
         self.sourcePrepath = os.path.abspath (utils.commandArgs.source) .replace ('\\', '/')
         self.sourceDir = '/'.join (self.sourcePrepath.split ('/') [ : -1])
         self.mainModuleName = self.sourcePrepath.split ('/') [-1]
-        self.targetDir = f'{self.sourceDir}/__target__'
+        if utils.commandArgs.outputdir:
+            # Set the output path relatively to the sourceDir
+            self.targetDir = os.path.abspath(os.path.relpath(utils.commandArgs.outputdir, start=self.sourceDir))
+        else:
+            self.targetDir = os.path.join(self.sourceDir, '__target__')
         self.optionsPath = f'{self.targetDir}/{self.mainModuleName}.options'
         
         # Find out if command line arguments are changed

--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -76,9 +76,9 @@ class Program:
         self.mainModuleName = self.sourcePrepath.split ('/') [-1]
         if utils.commandArgs.outputdir:
             # Set the output path relatively to the sourceDir
-            self.targetDir = os.path.abspath(os.path.relpath(utils.commandArgs.outputdir, start=self.sourceDir))
+            self.targetDir = os.path.abspath (os.path.relpath (utils.commandArgs.outputdir, start = self.sourceDir)).replace ('\\', '/')
         else:
-            self.targetDir = os.path.join(self.sourceDir, '__target__')
+            self.targetDir = f'{self.sourceDir}/__target__'
         self.optionsPath = f'{self.targetDir}/{self.mainModuleName}.options'
         
         # Find out if command line arguments are changed

--- a/transcrypt/modules/org/transcrypt/utils.py
+++ b/transcrypt/modules/org/transcrypt/utils.py
@@ -61,6 +61,7 @@ class CommandArgs:
         self.argParser.add_argument ('-l', '--license', help = "show license", action = 'store_true')
         self.argParser.add_argument ('-m', '--map', help = "generate source map", action = 'store_true')
         self.argParser.add_argument ('-n', '--nomin', help = "no minification", action = 'store_true')
+        self.argParser.add_argument ('-od', '--outputdir', help='override the output directory path (default = __target__)')
         self.argParser.add_argument ('-o', '--opov', help = "enable operator overloading by default. In general this is disadvised, use __pragma__ ('opov') and __pragma__('noopov') locally instead to prevent slow code", action = 'store_true')
         self.argParser.add_argument ('-p', '--parent', nargs='?', help = "object that will hold application, default is window. Use -p .none to generate orphan application, e.g. for use in node.js")
         self.argParser.add_argument ('-r', '--run', help = "run source file rather than compiling it", action = 'store_true')


### PR DESCRIPTION
Adds a command-line flag (`-od` / `--outputdir`) to override the default output directory (`__target__`). Path is relative to the source directory, unless it is absolute (e.g. `/home/momo/...`)