### PR TITLE
Fix `with` statement for multiple context managers

### DIFF
--- a/transcrypt/development/automated_tests/transcrypt/control_structures/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/control_structures/__init__.py
@@ -125,3 +125,15 @@ def run (autoTester):
     finally:
         autoTester.check ('ctx5', contextManagerExample5.counter, externalCounter5)
         autoTester.check ('ctx4', contextManagerExample4.counter, externalCounter4) 
+
+    # multiple context managers in one clause
+    iterationCount = 0
+    with ContextManagerExample (), ContextManagerExample ():
+        iterationCount += 1
+    autoTester.check('ctx7', iterationCount)
+
+    iterationCount = 0
+    with ContextManagerExample (), ContextManagerExample (), ContextManagerExample (), \
+         ContextManagerExample(), ContextManagerExample ():
+        iterationCount += 1
+    autoTester.check('ctx8', iterationCount)


### PR DESCRIPTION
The previous implementation would call the body of `with` multiple times, if it contains multiple context managers.

For example, for the following code:

```
  with a, b:
      fn()
```

would be generated the equivalent of this:

```
  with a:
      fn()

  with b:
      fn()
```