### PR TITLE
Corrected sourcePath info in Errors

### DIFF
--- a/transcrypt/modules/org/transcrypt/utils.py
+++ b/transcrypt/modules/org/transcrypt/utils.py
@@ -195,13 +195,13 @@ class Error (Exception):
             
     def __str__ (self):
         result = 'Error while compiling (offending file last):'
-        
-        try:
-            sourcePath = importRecord [0] .sourcePath
-        except:
-            sourcePath = '<unknown>'
-            
+
         for importRecord in program.importStack [ : -1]:
+            try:
+                sourcePath = importRecord[0].sourcePath
+            except:
+                sourcePath = '<unknown>'
+
             result += '\n\tFile \'{}\', line {}, at import of:'.format (sourcePath, importRecord [1])
             
         result += '\n\tFile \'{}\', line {}, namely:'.format (str (program.importStack [-1][0] ), self.lineNr)


### PR DESCRIPTION
Currently, Transcrypt reports something like
```
Error while compiling (offending file last):
        File '<unknown>', line 32, at import of:
        File '<unknown>', line 4, at import of:
        File '<org.transcrypt.compiler.Module object at 0x7f89eb64fda0>', line 4, namely:
```
this fixes it so that
```
Error while compiling (offending file last):
        File '/home/user/game/game.py', line 32, at import of:
        File '/home/user/game/html5/__init__.py', line 4, at import of:
        File '<org.transcrypt.compiler.Module object at 0x7fd6746f6c50>', line 4, namely:
```
will be reported.