### PR TITLE
Fixing compatibility issue with Ember.js

### DIFF
--- a/transcrypt/modules/org/transcrypt/__core__.js
+++ b/transcrypt/modules/org/transcrypt/__core__.js
@@ -181,6 +181,9 @@ export var py_metatype = {
             var base = bases [index];
             for (var attrib in base) {
                 var descrip = Object.getOwnPropertyDescriptor (base, attrib);
+                if (descrip == null) {  // Another library modified Function.prototype
+                    continue;
+                }
                 Object.defineProperty (cls, attrib, descrip);
             }           
             for (let symbol of Object.getOwnPropertySymbols (base)) {


### PR DESCRIPTION
I am having some issues trying to use Transcrypt with Ember.js.

So the way the bug works is that Ember [modifies the Function prototype](https://github.com/emberjs/ember.js/blob/d6352a54c068354da93bcb26a5df4c7ef9153ea7/packages/ember-runtime/lib/ext/function.js#L76). When this happens, the newly created `cls` inherits all of the attributes attached to the Function prototype. During the `for (var attrib in base)` loop, these inherited attributes show up. But since they were applied directly to the prototype object instead of by using `defineProperty`, `getOwnPropertyDescriptor` returns `null`. This then fails during the call to `defineProperty`, saying that the descriptor must not be null.

I know this use case is a little bit niche, but I was wondering if you would consider this fix, or if there is another way to go about resolving this. Thanks!