### PR TITLE
Travis CI: The sudo tag is now deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: yes
 
 addons:
     chrome: stable


### PR DESCRIPTION
__sudo: required__ no longer is.  The __sudo__ command is now always available in Travis CI and there is no way to turn it off.