### PR TITLE
CI: Look for Python syntax errors and undefined names

### DIFF
--- a/transcrypt/development/continuous_integration/run.sh
+++ b/transcrypt/development/continuous_integration/run.sh
@@ -13,7 +13,7 @@ ls -a -l
 
 # Look for Python syntax errors and undefined names
 
-flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+flake8 . --count --select=E9,F63,F7,F823 --show-source --statistics
 
 # Make everything executable and the rest
 

--- a/transcrypt/development/continuous_integration/run.sh
+++ b/transcrypt/development/continuous_integration/run.sh
@@ -4,13 +4,16 @@ ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 
 # Install Python modules
 
-pip install mypy
-pip install selenium
+pip install flake8 mypy selenium
 
 # Show where we are and what's there
 
 pwd
 ls -a -l
+
+# Look for Python syntax errors and undefined names
+
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 # Make everything executable and the rest
 

--- a/transcrypt/development/manual_tests/incidental_tests/indirect_import_error/module3.py
+++ b/transcrypt/development/manual_tests/incidental_tests/indirect_import_error/module3.py
@@ -1,1 +1,1 @@
-= nonsense =
+= nonsense =  # noqa

--- a/transcrypt/development/manual_tests/module_random/module_random.py
+++ b/transcrypt/development/manual_tests/module_random/module_random.py
@@ -3,6 +3,7 @@ from random import *
 result = ''
 
 def output (any):
+    global result
     result += any + '<br>\n'
 
 for fixedSeed in (False, True):

--- a/transcrypt/development/manual_tests/transcrypt_only/transcrypt_only.py
+++ b/transcrypt/development/manual_tests/transcrypt_only/transcrypt_only.py
@@ -3,6 +3,7 @@ from random import *
 result = ''
 
 def output (*any):
+    global result
     for item in any:
         result += str (item)
         result += ' '

--- a/transcrypt/modules/cmath/__init__.py
+++ b/transcrypt/modules/cmath/__init__.py
@@ -2,10 +2,10 @@ pi = Math.PI
 e = Math.E
 
 def phase (x):
-    return 0 if __typeof__ (x) is 'number' else Math.atan2 (x.imag, x.real)
+    return 0 if __typeof__ (x) == 'number' else Math.atan2 (x.imag, x.real)
     
 def polar (x):
-    return (Math.abs (x), 0) if __typeof__ (x) is 'number' else (abs (x), phase (x))
+    return (Math.abs (x), 0) if __typeof__ (x) == 'number' else (abs (x), phase (x))
     
 def rect (r, phi):
     __pragma__ ('opov')
@@ -13,11 +13,11 @@ def rect (r, phi):
     __pragma__ ('noopov')
     
 def exp (x):
-    return complex (x, 0) .__exp__ () if __typeof__ (x) is 'number' else x.__exp__ ()
+    return complex (x, 0) .__exp__ () if __typeof__ (x) == 'number' else x.__exp__ ()
         
 def log (x, base):
     return (
-        complex (x, 0) .__log__ () if __typeof__ (x) is 'number' else x.__log__ ()
+        complex (x, 0) .__log__ () if __typeof__ (x) == 'number' else x.__log__ ()
     ) if base is js_undefined else (
         __truediv__ (log (x), log (base))   # Recursive
     )

--- a/transcrypt/modules/org/transcrypt/__runtime__.py
+++ b/transcrypt/modules/org/transcrypt/__runtime__.py
@@ -164,7 +164,7 @@ class complex:
         return self.__mul__ (Math.log (real)) .__exp__ ()
         
     def __mul__ (self, other):
-        if __typeof__ (other) is 'number':
+        if __typeof__ (other) == 'number':
             return complex (self.real * other, self.imag * other)
         else:
             return complex (self.real * other.real - self.imag * other.imag, self.real * other.imag + self.imag * other.real)
@@ -173,7 +173,7 @@ class complex:
         return complex (self.real * real, self.imag * real)
         
     def __div__ (self, other):
-        if __typeof__ (other) is 'number':
+        if __typeof__ (other) == 'number':
             return complex (self.real / other, self.imag / other)
         else:
             denom = other.real * other.real + other.imag * other.imag
@@ -190,7 +190,7 @@ class complex:
         )
         
     def __add__ (self, other):
-        if __typeof__ (other) is 'number':
+        if __typeof__ (other) == 'number':
             return complex (self.real + other, self.imag)
         else:   # Assume other is complex
             return complex (self.real + other.real, self.imag + other.imag)
@@ -199,7 +199,7 @@ class complex:
         return complex (self.real + real, self.imag)
         
     def __sub__ (self, other):
-        if __typeof__ (other) is 'number':
+        if __typeof__ (other) == 'number':
             return complex (self.real - other, self.imag)
         else:
             return complex (self.real - other.real, self.imag - other.imag)
@@ -214,13 +214,13 @@ class complex:
         return __repr__ (self) [1 : -1]
         
     def __eq__ (self, other):
-        if __typeof__ (other) is 'number':
+        if __typeof__ (other) == 'number':
             return self.real == other
         else:
             return self.real == other.real and self.imag == other.imag
         
     def __ne__ (self, other):
-        if __typeof__ (other) is 'number':
+        if __typeof__ (other) == 'number':
             return self.real != other
         else:
             return self.real != other.real or self.imag != other.imag


### PR DESCRIPTION
Add flake8 tests to jook for Python syntax errors and undefined names

Use ==/!= to compare str, bytes, and int literals
$ __python__
```
>>> number = "num"
>>> number += "ber"
>>> number == "number"
True
>>> number is "number"
False
```
Local variable 'result' defined in enclosing scope on line 3 referenced before assignment
$ __python__
```
>>> result = ''
>>>
>>> def output (any):
...     result += any + '<br>\n'
...
>>> output("test")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 2, in output
UnboundLocalError: local variable 'result' referenced before assignment
```