### PR TITLE
Travis CI: Run parallel test on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: xenial
-
 addons:
     chrome: stable
     apt:
@@ -9,6 +7,7 @@ addons:
 language: python
 python:
     - '3.7'
+    - '3.8-dev'
     
 script:
     - bash ./transcrypt/development/continuous_integration/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
 language: python
 python:
     - '3.7'
-    - '3.8-dev'
+    - '3.8'
     
 script:
     - bash ./transcrypt/development/continuous_integration/run.sh


### PR DESCRIPTION
Also, __Xenial__ is now Travis CI's default distro.