### PR TITLE
Nested `with __pragma__(...)`

### DIFF
--- a/transcrypt/development/automated_tests/transcrypt/operator_overloading/__init__.py
+++ b/transcrypt/development/automated_tests/transcrypt/operator_overloading/__init__.py
@@ -260,3 +260,14 @@ def run (autoTester):
     __pragma__('noopov')
     
     autoTester.check (a.b ['c'])
+
+    # nested __pragma__ context managers
+
+    with __pragma__ ('opov'):
+        autoTester.check ((2, 1, 3) == (1, 2, 3))
+        autoTester.check ([2, 1, 3] == [1, 2, 3])
+        with __pragma__ ('opov'):
+            autoTester.check ((1, 2, 3) != (1, 2, 3))
+            autoTester.check ([1, 2, 3] != [1, 2, 3])
+        autoTester.check ((1, 2, 3) == (1, 2, 3))
+        autoTester.check ([1, 2, 3] == [1, 2, 3])

--- a/transcrypt/modules/org/transcrypt/stubs/browser.py
+++ b/transcrypt/modules/org/transcrypt/stubs/browser.py
@@ -46,6 +46,15 @@ __symbols__ = []
 def __set_stubsymbols__ (symbols):
     global __symbols__
     __symbols__ = symbols
+
+
+class PragmaCtx:
+    def __enter__ (self):
+        pass
+
+    def __exit__ (self, a, b, c):
+        pass
+
     
 def __pragma__ (*args):
     if args [0] == 'defined':
@@ -53,4 +62,6 @@ def __pragma__ (*args):
             if arg in __symbols__:
                 return True
         return False
+    else:
+        return PragmaCtx()
     


### PR DESCRIPTION
Keeping on working for #552

In this changeset I've implemented stack for flags set and reset by pragmas. This allows us to solve `with __pragma__` nesting problem.

There is also `__pragma__('push')` and `__pragma__('pop')` for saving and restoring flag state from stack. I plan to use those to fix the smae nesting problem for single-line activated pragmas.

Aliases cannot be nested yet.

The tests is a bit lacking. I think, snapshot testing could be better soultion for testing pragmas.