### PR TITLE
Ignore 'property' decorator when transpiling function decorators

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -2689,7 +2689,7 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
                     self.emit ('__call__ (')
 
                 for decorator in node.decorator_list:
-                    if not (type (decorator) == ast.Name and decorator.id in ('classmethod', 'staticmethod')):
+                    if not (type (decorator) == ast.Name and decorator.id in ('classmethod', 'staticmethod', 'property')):
                         if decoratorsUsed > 0:
                             self.emit (' (')
                         self.visit (decorator)


### PR DESCRIPTION
## Change Summary
Like the `classmethod` and `staticmethod` decorators, the `property` decorator is handled differently from other decorators and is not 'stacked' in front of the function it decorates. That is unless you combine it with other decorators, in which case it is added to the stack and will cause errors at JS runtime. 

This PR aims to exclude the `property` decorator from the decorator stack, just like `classmethod` and `staticmethod` already are.

## Related issue number
Related to #658.

## PR Checklist

* [ ] Adapted tests
* [ ] Passes tests
* [ ] Documented changes