### PR TITLE
Make transcrypt-loader npm package Windows-compatible

### DIFF
--- a/transcrypt/bundlers/webpack/__target_es5__/index.js
+++ b/transcrypt/bundlers/webpack/__target_es5__/index.js
@@ -7,7 +7,7 @@ exports.main = exports.DEFAULT_PACKAGE_CONFIG = exports.loader_utils = exports.c
 
 var _orgTranscrypt__runtime__ = require("./org.transcrypt.__runtime__.js");
 
-// Transcrypt'ed from Python, 2018-12-31 09:55:46
+// Transcrypt'ed from Python, 2020-08-06 18:14:42
 var __name__ = '__main__';
 
 var path = require('path');
@@ -21,10 +21,7 @@ exports.child_process = child_process;
 var loader_utils = require('loader-utils');
 
 exports.loader_utils = loader_utils;
-var DEFAULT_PACKAGE_CONFIG = (0, _orgTranscrypt__runtime__.dict)({
-  'command': 'python3 -m transcrypt',
-  'arguments': (0, _orgTranscrypt__runtime__.list)(['--nomin', '--map', '--verbose'])
-});
+var DEFAULT_PACKAGE_CONFIG = (0, _orgTranscrypt__runtime__.dict)([['command', 'python3 -m transcrypt'], ['arguments', ['--nomin', '--map', '--verbose']]]);
 exports.DEFAULT_PACKAGE_CONFIG = DEFAULT_PACKAGE_CONFIG;
 
 var main = function main(src) {
@@ -42,15 +39,17 @@ var main = function main(src) {
 
   var target_path = path.join(this.rootContext, '__target__', py_module) + '.js';
   var import_path = './' + path.relative(fileinfo.dir, target_path);
+
+  if (path.sep == '\\') {
+    var import_path = import_path.py_replace('\\', '/');
+  }
+
   var runinfo_path = path.join(this.rootContext, '__target__', relative_dir, fileinfo.name) + '.transcrypt.json';
-  var cmd = (0, _orgTranscrypt__runtime__.list)([]);
+  var cmd = [];
   cmd.append(config['command']);
   cmd.extend(config['arguments']);
   cmd.append('"{}"'.format(py_module.py_replace('"', '\\"')));
-  var cmd_options = (0, _orgTranscrypt__runtime__.dict)({
-    'cwd': this.rootContext,
-    'encoding': 'utf8'
-  });
+  var cmd_options = (0, _orgTranscrypt__runtime__.dict)([['cwd', this.rootContext], ['encoding', 'utf8']]);
 
   try {
     var stdout = (0, _orgTranscrypt__runtime__.str)(child_process.execSync(' '.join(cmd), cmd_options));

--- a/transcrypt/bundlers/webpack/__target_es5__/org.transcrypt.__runtime__.js
+++ b/transcrypt/bundlers/webpack/__target_es5__/org.transcrypt.__runtime__.js
@@ -114,14 +114,14 @@ function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
-// Transcrypt'ed from Python, 2018-12-31 09:55:46
+// Transcrypt'ed from Python, 2020-08-06 18:14:42
 var __name__ = 'org.transcrypt.__runtime__';
 var __envir__ = {};
 exports.__envir__ = __envir__;
 __envir__.interpreter_name = 'python';
 __envir__.transpiler_name = 'transcrypt';
 __envir__.executor_name = __envir__.transpiler_name;
-__envir__.transpiler_version = '3.7.11';
+__envir__.transpiler_version = '3.7.16';
 
 function __nest__(headObject, tailNames, value) {
   var current = headObject;
@@ -1634,10 +1634,10 @@ __setproperty__(String.prototype, 'format', {
         }
 
         if (key == +key) {
-          return args[key] == undefined ? match : str(args[key]);
+          return args[key] === undefined ? match : str(args[key]);
         } else {
           for (var index = 0; index < args.length; index++) {
-            if (_typeof(args[index]) == 'object' && args[index][key] != undefined) {
+            if (_typeof(args[index]) == 'object' && args[index][key] !== undefined) {
               return str(args[index][key]);
             }
           }

--- a/transcrypt/bundlers/webpack/index.py
+++ b/transcrypt/bundlers/webpack/index.py
@@ -40,6 +40,8 @@ def main(src):
         py_module = path.join(relative_dir, fileinfo.js_name).split(path.sep).join('.')
     target_path = path.join(this.rootContext, '__target__', py_module) + '.js'
     import_path = './' + path.relative(fileinfo.dir, target_path)
+    if path.sep == '\\':  # Windows OS
+        import_path = import_path.replace('\\', '/')
     runinfo_path = path.join(this.rootContext, '__target__', relative_dir, fileinfo.js_name) + '.transcrypt.json'
 
     # run transcrypt

--- a/transcrypt/bundlers/webpack/package.json
+++ b/transcrypt/bundlers/webpack/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "transcrypt-loader",
   "description": "Code in Python 3. Bundle to Javascript.",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
   },
   "main": "__target_es5__/index.js",
   "scripts": {
-    "build": "python3 -m transcrypt --build --map --nomin index.py && node ./node_modules/.bin/babel __target__/ -d ./__target_es5__/"
+    "build": "python3 -m transcrypt --build --map --nomin index.py && babel __target__/ -d ./__target_es5__/"
   },
   "dependencies": {
     "loader-utils": "^1.2.3"

--- a/transcrypt/bundlers/webpack/package.json
+++ b/transcrypt/bundlers/webpack/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/QQuick/Transcrypt"
+    "url": "https://github.com/QQuick/Transcrypt/tree/parcel-bundler2"
   },
   "main": "__target_es5__/index.js",
   "scripts": {


### PR DESCRIPTION
Addresses issue #624 by checking if we are running on Windows and replacing the backslashes in `import_path` with forward slashes. The main change is [https://github.com/QQuick/Transcrypt/compare/parcel-bundler2...phistrom:parcel-bundler2?expand=1#diff-ba37ae7716bc43a1a120b784aee4b09eR44](https://github.com/QQuick/Transcrypt/compare/parcel-bundler2...phistrom:parcel-bundler2?expand=1#diff-ba37ae7716bc43a1a120b784aee4b09eR44).

I think @doconix will have to be the one to upload to npm.