### PR TITLE
Please help with defaultdict implementation

### DIFF
--- a/transcrypt/modules/collections.py
+++ b/transcrypt/modules/collections.py
@@ -1,0 +1,28 @@
+"""Python's collections module -- for Transcrypt."""
+
+
+class defaultdict(dict):
+    """Dictionary that takes a factory parameter and always returns a value."""
+
+    def __init__(self, default_factory=None, *args, **kwargs):  # noqa
+        if not callable(default_factory) and default_factory is not None:
+            raise TypeError("first argument must be callable or None")
+        super().__init__(*args, **kwargs)
+        self.default_factory = default_factory
+
+    def __repr__(self):
+        return "defaultdict({}, {})".format(
+            self.default_factory, super().__repr__(self)
+        )
+
+    def __missing__(self, key: str):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = self.default_factory()
+        return super().__getitem__(key)
+
+    def __getitem__(self, key: str):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            return self.__missing__(key)


### PR DESCRIPTION
While trying to make a Python validation library work in the browser, I thought I'd prefer not to change the library and just pay for it with 25 lines in Transcrypt.

I thought this simple implementation of defaultdict would work, but Firefox complains:

    Uncaught TypeError: meta is undefined
    __class__ org.transcrypt.__runtime__.py:4
    <anonymous> collections.py:4

I suppose *dict* is not a Python class in Transcrypt -- is it just a JS object?

In any case, please let me know what's going on and give me a north.