### PR TITLE
Embedded HTML similar to JSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,14 @@ setup (
 		read ('README.rst')
 	),
 	keywords = ['python', 'javascript', 'transpiler', 'compiler', 'browser', 'web', 'multiple inheritance', 'transcrypt', 'django'],
-	url = 'http://www.transcrypt.org',	
+	url = 'http://www.transcrypt.org',
 	license = 'Apache 2.0',
 	author = 'Jacques de Hooge',
 	author_email = 'jacques.de.hooge@qquick.org',
 	packages = ['transcrypt'],
 	install_requires = [
-		'mypy'
+		'mypy',
+		'ideas',
 	],
 	entry_points = {
 		'console_scripts': [

--- a/transcrypt/__main__.py
+++ b/transcrypt/__main__.py
@@ -31,7 +31,7 @@ modulesDir = '{}/modules'.format (transpilerDir)                                
 sys.path = [item.replace ('\\', '/') for item in sys.path]
 
 # Unload org from a packages dir, if it happens to be there in the CPython installation
-sys.modules.pop ('org', None)   
+sys.modules.pop ('org', None)
 
 # Transcrypt needs to find modulesDir before CPython modules, so it will favor Transcrypt modules
 candidateTranspilationDirs = [modulesDir] + sys.path
@@ -49,7 +49,7 @@ for candidateTranspilationDir in candidateTranspilationDirs:
 # The following imports are needed by Transcrypt itself, not by transpiled or executed user code
 # They will either reload the previously unloaded org or load org from different location
 # CPython needs to find modulesDir after CPython modules, so it will favor CPython modules
-sys.path.append (modulesDir)      
+sys.path.append (modulesDir)
 from org.transcrypt import utils
 from org.transcrypt import compiler
 exitCodeNames = ('exitSuccess', 'exitCommandArgsError', 'exitNoLicense', 'exitSourceNotGiven', 'exitCannotRunSource', 'exitSpecificCompileError', 'exitGeneralCompileError')
@@ -62,17 +62,17 @@ def main ():
 
     def exitHandler ():
         if exitCode == exitSuccess:
-            utils.log (True, '\nReady\n\n')       
+            utils.log (True, '\nReady\n\n')
         else:
             utils.log (True, '\nAborted\n\n')
-            
+
     atexit.register (exitHandler)
-    
+
     def setExitCode (anExitCode):
         nonlocal exitCode
         exitCode = anExitCode
         return exitCode
-    
+
     try:
         __envir__ = utils.Any ()
         with tokenize.open (f'{modulesDir}/org/transcrypt/__envir__.js') as envirFile:
@@ -81,73 +81,73 @@ def main ():
 
         utils.log (True, '\n{} (TM) Python to JavaScript Small Sane Subset Transpiler Version {}\n', __envir__.transpiler_name.capitalize (), __envir__.transpiler_version)
         utils.log (True, 'Copyright (C) Geatec Engineering. License: Apache 2.0\n\n')
-        
+
         utils.log (True, '\n')
-        licensePath = '{}/{}'.format (transpilerDir, 'license_reference.txt')   
+        licensePath = '{}/{}'.format (transpilerDir, 'license_reference.txt')
         if not os.path.isfile (licensePath):
             utils.log (True, 'Error: missing license reference file\n')
             return setExitCode (exitNoLicense)
-            
+
         utils.commandArgs.parse ()
-        
+
         if utils.commandArgs.license:
             with open (licensePath) as licenseFile:
                 bar = 80 * '*'
                 utils.log (True, '\n{}\n\n', bar)
                 utils.log (True, '{}\n', licenseFile.read ())
                 utils.log (True, '{}\n\n', bar)
-                
+
         if utils.commandArgs.star:
             webbrowser.open ('https://github.com/qquick/Transcrypt')
-            
+
         if not utils.commandArgs.source:
             return setExitCode (exitSourceNotGiven) # Should never be here, dealth with by command arg checks already
-            
+
         if utils.commandArgs.source.endswith ('.py') or utils.commandArgs.source.endswith ('.js'):
             utils.commandArgs.source = utils.commandArgs.source [:-3]   # Ignore extension
             # This may be done in a more concise way, but it runs deeper than it may seem, so test any changes extensively
-        
+
         # Prepend paths that are needed by transpiled or executed user code, since they have to be searched first
         # So user code favors Transcrypt modules over CPython modules
         extraDirs = utils.commandArgs.xpath.replace ('#', ' ') .split ('$') if utils.commandArgs.xpath else []
-        
+
         sourcePath = utils.commandArgs.source.replace ('\\', '/')               # May be absolute or relative, in the latter case it may or may not specify a directory
         if '/' in sourcePath:                                                   # If directory specified
             sourceDir = sourcePath.rsplit ('/', 1)[0]                           #   Use it as source directory
         else:                                                                   # Else
             sourceDir = os.getcwd () .replace ('\\', '/')                       #   Use current working directory as source directory
-            
+
         projectDirs = [sourceDir] + extraDirs
-        
+
         sys.path [0 : 0] = projectDirs
-        
+
         global transpilationDirs
-        transpilationDirs [0 : 0] = projectDirs 
-                       
+        transpilationDirs [0 : 0] = projectDirs
+
         __symbols__ = utils.commandArgs.symbols.split ('$') if utils.commandArgs.symbols else []
-            
+
         if utils.commandArgs.complex:
             __symbols__.append ('__complex__')
 
         if utils.commandArgs.sform:
             __symbols__.append ('__sform__')
-            
+
         if utils.commandArgs.xtiny:
             __symbols__.append ('__xtiny__')
-            
+
         __symbols__.append ('__py{}.{}__'.format (* sys.version_info [:2]))
-            
+
         if utils.commandArgs.esv:
             __symbols__.append ('__esv{}__'.format (utils.commandArgs.esv))
         else:
             __symbols__.append ('__esv{}__'.format (utils.defaultJavaScriptVersion))
-         
+
         # Import (ignored when transpiling) late, since commandArgs must be set already
         from org.transcrypt.stubs.browser import __set_stubsymbols__
-        
+
         # Make symbols available to CPython, seems that exec can't do that directly
         __set_stubsymbols__ (__symbols__)
-        
+
         if utils.commandArgs.run:
             try:
                 with open (utils.commandArgs.source + '.py') as sourceFile:
@@ -163,25 +163,25 @@ def main ():
                 return setExitCode (exitSuccess)
             except utils.Error as error:
                 utils.log (True, '\n{}\n', error)
-                
+
                 # Don't log anything else, even in verbose mode, since this would only be confusing
                 if utils.commandArgs.dextex:
                     utils.log (True, '{}\n', traceback.format_exc ())
-                    
+
                 return setExitCode (exitSpecificCompileError)
             except Exception as exception:
                 utils.log (True, '\n{}', exception)
-                
+
                 # Have to log something else, because a general exception isn't informative enough
                 utils.log (True, '{}\n', traceback.format_exc ())
-                
+
                 return setExitCode (exitGeneralCompileError)
-                
+
     except utils.CommandArgsError:
         return setExitCode (exitCommandArgsError)
-        
+
     except utils.CommandArgsExit:
         return setExitCode (exitSuccess)
-            
+
 if __name__ == '__main__':
     sys.exit (main ())

--- a/transcrypt/modules/org/transcrypt/compiler1.py
+++ b/transcrypt/modules/org/transcrypt/compiler1.py
@@ -32,6 +32,7 @@ import collections
 import json
 from contextlib import contextmanager, ExitStack
 
+import ideas.examples.embedded_html
 from org.transcrypt import utils, sourcemaps, minify, static_check, type_check
 
 inIf = False
@@ -71,10 +72,10 @@ class Program:
 
         # Set paths
         self.sourcePrepath = os.path.abspath (utils.commandArgs.source) .replace ('\\', '/')
-        
+
         self.sourceDir = '/'.join (self.sourcePrepath.split ('/') [ : -1])
         self.mainModuleName = self.sourcePrepath.split ('/') [-1]
-        
+
         if utils.commandArgs.outdir:
             if os.path.isabs (utils.commandArgs.outdir):
                 self.targetDir = utils.commandArgs.outdir.replace ('\\', '/')
@@ -82,7 +83,7 @@ class Program:
                 self.targetDir = f'{self.sourceDir}/{utils.commandArgs.outdir}'.replace ('\\', '/')
         else:
             self.targetDir = f'{self.sourceDir}/__target__'.replace ('\\', '/')
-        
+
         self.projectPath = f'{self.targetDir}/{self.mainModuleName}.project'
 
         # Load the most recent project metadata
@@ -381,7 +382,7 @@ class Module:
             # This function turns comment-like pragma's into regular ones, both for multi-line and single-line pragma's
             # It changes rather than regenerates the sourcecode, since tokenize/untokenize will mess up formatting
             # Single line pragma's are always comment-like and will be turned into multi-line function-like pragma's
-            # Also in this function executable comments are converted to normal code 
+            # Also in this function executable comments are converted to normal code
 
             # Tokenize the source code, to be able to recognize comments easily
             tokens = tokenize.tokenize (io.BytesIO (sourceCode.encode ('utf-8')) .readline)
@@ -396,16 +397,16 @@ class Module:
                 if tokenType == tokenize.COMMENT:
                     strippedComment = tokenString [1 : ] .lstrip ()
                     if  strippedComment.startswith ('__pragma__'):
-                    
+
                        # Remember line index of multi-line pragma, like: # __pragma__ (...
                         pragmaCommentLineIndices.append (startRowColumn [0] - 1)
                     elif strippedComment.replace (' ', '') .replace ('\t', '') .startswith ('__:'):
-                    
+
                         # Remember line index of single-line pragma, like: <some code> # __: ...
                         shortPragmaCommentLineIndices.append (startRowColumn [0] - 1)
                 if tokenType == tokenize.NAME and tokenString == '__pragma__':
                     pragmaIndex = tokenIndex
-                    
+
                 if tokenIndex - pragmaIndex == 2:
                     pragmaKind = tokenString [1:-1]
                     if pragmaKind == 'ecom':
@@ -415,20 +416,20 @@ class Module:
 
             # Convert original, non-tokenized sourcecode to a list of lines
             sourceLines = sourceCode.split ('\n')
-            
+
             # Use line indices of multi-line function-like ecom / noecom pragma's to transform these lines into executable comment switches
             for ecomPragmaLineIndex in ecomPragmaLineIndices:
                 sourceLines [ecomPragmaLineIndex] = ecom
             for noecomPragmaLineIndex in noecomPragmaLineIndices:
                 sourceLines [noecomPragmaLineIndex] = noecom
-                        
+
             # Use line indices of multi-line comment-like pragma singles to transform these into function-like pragma singles (which often turn out te be part of a matching pair)
             allowExecutableComments = utils.commandArgs.ecom
             for pragmaCommentLineIndex in pragmaCommentLineIndices:
                 indentation, separator, tail = sourceLines [pragmaCommentLineIndex] .partition ('#')
                 pragma, separator, comment = tail.partition ('#')
                 pragma = pragma.replace (' ', '') .replace ('\t', '')
-                
+
                 # Turn appropriate lines into executable comment switches
                 if "('ecom')" in pragma or '("ecom")' in pragma:
                     allowExecutableComments = True
@@ -445,17 +446,17 @@ class Module:
                 strippedHead = head.lstrip ()
                 indent = head [ : len (head) - len (strippedHead)]
                 pragmaName = tail.replace (' ', '') .replace ('\t', '') [3:]
-                
+
                 # Turn appropriate lines into executable comment switches
                 if pragmaName == 'ecom':
-                    sourceLines [pragmaCommentLineIndex] = ecom             
+                    sourceLines [pragmaCommentLineIndex] = ecom
                 elif pragmaName == 'noecom':
-                    sourceLines [pragmaCommentLineIndex] = noecom                
+                    sourceLines [pragmaCommentLineIndex] = noecom
                 elif pragmaName.startswith ('no'):
                     sourceLines [shortPragmaCommentLineIndex] = '{}__pragma__ (\'{}\'); {}; __pragma__ (\'{}\')' .format (indent, pragmaName, head, pragmaName [2:])    # Correct!
                 else:
                     sourceLines [shortPragmaCommentLineIndex] = '{}__pragma__ (\'{}\'); {}; __pragma__ (\'no{}\')' .format (indent, pragmaName, head, pragmaName)
-                    
+
             # Switch executable comments on c.q. off and turn executable comments into normal code lines for Transcrypt (as opposed to CPython)
             uncommentedSourceLines = []
             for sourceLine in sourceLines:
@@ -469,7 +470,7 @@ class Module:
                         uncommentedSourceLines.append (sourceLine.replace ('#?', '', 1) if lStrippedSourceLine.startswith ('#?') else sourceLine)
                 else:
                     uncommentedSourceLines.append (sourceLine)
-                    
+
             # Return joined lines, to be used for parsing
             return '\n'.join (uncommentedSourceLines)
 
@@ -477,8 +478,8 @@ class Module:
             utils.log (False, 'Parsing module: {}\n', self.sourcePath)
 
             with tokenize.open (self.sourcePath) as sourceFile:
-                self.sourceCode = utils.extraLines + sourceFile.read ()
-                
+                self.sourceCode = utils.extraLines + ideas.examples.embedded_html.transform_source(sourceFile.read ())
+
             self.parseTree = ast.parse (pragmasFromComments (self.sourceCode))
 
             for node in ast.walk (self.parseTree):
@@ -2405,14 +2406,14 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
 
         if len (node.comparators) > 1:
             self.emit(')')
-            
+
     def visit_Constant (self, node):
         if type (node.value) == str:
             self.emit ('{}', repr (node.s)) # Use repr (node.s) as second, rather than first parameter, since node.s may contain {}
         elif type (node.value) == bytes:
-            self.emit ('bytes (\'{}\')', node.s.decode ('ASCII'))            
+            self.emit ('bytes (\'{}\')', node.s.decode ('ASCII'))
         elif type (node.value) == complex:
-            self.emit ('complex (0, {})'.format (node.n.imag))           
+            self.emit ('complex (0, {})'.format (node.n.imag))
         elif type (node.value) in {float, int}:
             self.emit ('{}'.format (node.n))
         else:

--- a/transcrypt/modules/org/transcrypt/compiler38.py
+++ b/transcrypt/modules/org/transcrypt/compiler38.py
@@ -32,6 +32,8 @@ import collections
 import json
 from contextlib import contextmanager, ExitStack
 
+import ideas.examples.embedded_html
+
 from org.transcrypt import utils, sourcemaps, minify, static_check, type_check
 
 inIf = False
@@ -71,10 +73,10 @@ class Program:
 
         # Set paths
         self.sourcePrepath = os.path.abspath (utils.commandArgs.source) .replace ('\\', '/')
-        
+
         self.sourceDir = '/'.join (self.sourcePrepath.split ('/') [ : -1])
         self.mainModuleName = self.sourcePrepath.split ('/') [-1]
-        
+
         if utils.commandArgs.outdir:
             if os.path.isabs (utils.commandArgs.outdir):
                 self.targetDir = utils.commandArgs.outdir.replace ('\\', '/')
@@ -82,7 +84,7 @@ class Program:
                 self.targetDir = f'{self.sourceDir}/{utils.commandArgs.outdir}'.replace ('\\', '/')
         else:
             self.targetDir = f'{self.sourceDir}/__target__'.replace ('\\', '/')
-        
+
         self.projectPath = f'{self.targetDir}/{self.mainModuleName}.project'
 
         # Load the most recent project metadata
@@ -381,7 +383,7 @@ class Module:
             # This function turns comment-like pragma's into regular ones, both for multi-line and single-line pragma's
             # It changes rather than regenerates the sourcecode, since tokenize/untokenize will mess up formatting
             # Single line pragma's are always comment-like and will be turned into multi-line function-like pragma's
-            # Also in this function executable comments are converted to normal code 
+            # Also in this function executable comments are converted to normal code
 
             # Tokenize the source code, to be able to recognize comments easily
             tokens = tokenize.tokenize (io.BytesIO (sourceCode.encode ('utf-8')) .readline)
@@ -396,16 +398,16 @@ class Module:
                 if tokenType == tokenize.COMMENT:
                     strippedComment = tokenString [1 : ] .lstrip ()
                     if  strippedComment.startswith ('__pragma__'):
-                    
+
                        # Remember line index of multi-line pragma, like: # __pragma__ (...
                         pragmaCommentLineIndices.append (startRowColumn [0] - 1)
                     elif strippedComment.replace (' ', '') .replace ('\t', '') .startswith ('__:'):
-                    
+
                         # Remember line index of single-line pragma, like: <some code> # __: ...
                         shortPragmaCommentLineIndices.append (startRowColumn [0] - 1)
                 if tokenType == tokenize.NAME and tokenString == '__pragma__':
                     pragmaIndex = tokenIndex
-                    
+
                 if tokenIndex - pragmaIndex == 2:
                     pragmaKind = tokenString [1:-1]
                     if pragmaKind == 'ecom':
@@ -415,20 +417,20 @@ class Module:
 
             # Convert original, non-tokenized sourcecode to a list of lines
             sourceLines = sourceCode.split ('\n')
-            
+
             # Use line indices of multi-line function-like ecom / noecom pragma's to transform these lines into executable comment switches
             for ecomPragmaLineIndex in ecomPragmaLineIndices:
                 sourceLines [ecomPragmaLineIndex] = ecom
             for noecomPragmaLineIndex in noecomPragmaLineIndices:
                 sourceLines [noecomPragmaLineIndex] = noecom
-                        
+
             # Use line indices of multi-line comment-like pragma singles to transform these into function-like pragma singles (which often turn out te be part of a matching pair)
             allowExecutableComments = utils.commandArgs.ecom
             for pragmaCommentLineIndex in pragmaCommentLineIndices:
                 indentation, separator, tail = sourceLines [pragmaCommentLineIndex] .partition ('#')
                 pragma, separator, comment = tail.partition ('#')
                 pragma = pragma.replace (' ', '') .replace ('\t', '')
-                
+
                 # Turn appropriate lines into executable comment switches
                 if "('ecom')" in pragma or '("ecom")' in pragma:
                     allowExecutableComments = True
@@ -445,17 +447,17 @@ class Module:
                 strippedHead = head.lstrip ()
                 indent = head [ : len (head) - len (strippedHead)]
                 pragmaName = tail.replace (' ', '') .replace ('\t', '') [3:]
-                
+
                 # Turn appropriate lines into executable comment switches
                 if pragmaName == 'ecom':
-                    sourceLines [pragmaCommentLineIndex] = ecom             
+                    sourceLines [pragmaCommentLineIndex] = ecom
                 elif pragmaName == 'noecom':
-                    sourceLines [pragmaCommentLineIndex] = noecom                
+                    sourceLines [pragmaCommentLineIndex] = noecom
                 elif pragmaName.startswith ('no'):
                     sourceLines [shortPragmaCommentLineIndex] = '{}__pragma__ (\'{}\'); {}; __pragma__ (\'{}\')' .format (indent, pragmaName, head, pragmaName [2:])    # Correct!
                 else:
                     sourceLines [shortPragmaCommentLineIndex] = '{}__pragma__ (\'{}\'); {}; __pragma__ (\'no{}\')' .format (indent, pragmaName, head, pragmaName)
-                    
+
             # Switch executable comments on c.q. off and turn executable comments into normal code lines for Transcrypt (as opposed to CPython)
             uncommentedSourceLines = []
             for sourceLine in sourceLines:
@@ -469,7 +471,7 @@ class Module:
                         uncommentedSourceLines.append (sourceLine.replace ('#?', '', 1) if lStrippedSourceLine.startswith ('#?') else sourceLine)
                 else:
                     uncommentedSourceLines.append (sourceLine)
-                    
+
             # Return joined lines, to be used for parsing
             return '\n'.join (uncommentedSourceLines)
 
@@ -477,8 +479,8 @@ class Module:
             utils.log (False, 'Parsing module: {}\n', self.sourcePath)
 
             with tokenize.open (self.sourcePath) as sourceFile:
-                self.sourceCode = utils.extraLines + sourceFile.read ()
-                
+                self.sourceCode = utils.extraLines + ideas.examples.embedded_html.transform_source(sourceFile.read ())
+
             self.parseTree = ast.parse (pragmasFromComments (self.sourceCode))
 
             for node in ast.walk (self.parseTree):
@@ -2400,14 +2402,14 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
 
         if len (node.comparators) > 1:
             self.emit(')')
-            
+
     def visit_Constant (self, node):
         if type (node.value) == str:
             self.emit ('{}', repr (node.s)) # Use repr (node.s) as second, rather than first parameter, since node.s may contain {}
         elif type (node.value) == bytes:
-            self.emit ('bytes (\'{}\')', node.s.decode ('ASCII'))            
+            self.emit ('bytes (\'{}\')', node.s.decode ('ASCII'))
         elif type (node.value) == complex:
-            self.emit ('complex (0, {})'.format (node.n.imag))           
+            self.emit ('complex (0, {})'.format (node.n.imag))
         elif type (node.value) in {float, int}:
             self.emit ('{}'.format (node.n))
         else:

--- a/transcrypt/modules/org/transcrypt/utils.py
+++ b/transcrypt/modules/org/transcrypt/utils.py
@@ -17,17 +17,17 @@ defaultJavaScriptVersion = 5
 
 class CommandArgsError (BaseException):
     pass
-    
+
 class CommandArgsExit (BaseException):
     pass
-    
+
 class ArgumentParser (argparse.ArgumentParser):
     def error (self, message):
         self.print_help (sys.stdout)
         if message:
             log (True, '\nError: {}\n', message)
         raise CommandArgsError ()
-        
+
     def exit (self, status = 0, message = None):
         if message:
             log (True, 'Exit: {}', message)
@@ -36,7 +36,7 @@ class ArgumentParser (argparse.ArgumentParser):
 class CommandArgs:
     def parse (self):
         self.argParser = ArgumentParser ()
-        
+
         self.argParser.add_argument ('source', nargs='?', help = ".py file containing source code of main module")
         self.argParser.add_argument ('-a', '--anno', help = "annotate target files that were compiled from Python with source file names and source line numbers", action = 'store_true')
         self.argParser.add_argument ('-am', '--alimod', help = "use aliasing for module paths", action = 'store_true')
@@ -79,35 +79,35 @@ class CommandArgs:
         self.argParser.add_argument ('-xp', '--xpath', nargs = '?', help = "additional module search paths, joined by $, #'s will be replaced by spaces")
         self.argParser.add_argument ('-xt', '--xtiny', help = "generate tiny version of runtime, a.o. lacking support for implicit and explicit operator overloading. Use only if generated code can be validated, since it will introduce semantic alterations in edge cases", action = 'store_true')
         self.argParser.add_argument ('-*', '--star', help = "Like it? Grow it! Go to GitHub and then click [* Star]", action = 'store_true')
-        
+
         self.projectOptions = self.argParser.parse_args () .__dict__
         self.__dict__.update (self.projectOptions)
-        
+
         # Signal invalid switches
-        
+
         def logAndExit (message):
             log (True, message)
             sys.exit (1)
-        
+
         invalidCombi = 'Invalid combination of options'
-        
+
         if not (self.license or self.star or self.source):
             logAndExit (self.argParser.format_usage () .capitalize ())
         elif self.map and self.unit:
-            logAndExit ('{}: -m / --map and -u / --unit'.format (invalidCombi))   
+            logAndExit ('{}: -m / --map and -u / --unit'.format (invalidCombi))
         elif self.parent and self.unit == '.com':
             logAndExit ('{}: -p / --parent and -u / --unit .com'.format (invalidCombi))
         elif self.parent == '.export' and self.esv and int (self.esv) < 6:
-            logAndExit ('{}: -p / --parent .export and -e / --esv < 6'.format (invalidCombi))        
+            logAndExit ('{}: -p / --parent .export and -e / --esv < 6'.format (invalidCombi))
         elif self.unit == '.auto' and self.esv and int (self.esv) < 6:
             logAndExit ('{}: -u / --unit .auto and -e / --esv < 6'.format (invalidCombi))
-        
+
         # Set dependent switches
-        
+
         # (for future use)
-            
+
         # Correcting line counts for source map
-            
+
         global extraLines
         extraLines = [
             # Make identifier __pragma__ known to static checker
@@ -115,57 +115,57 @@ class CommandArgs:
             # __ pragma__ ('<all>') in JavaScript requires it to remain a function, as it was in the core
             # It can't be skipped, since it has to precede __pragma__ ('skip'), to make the checker accept that
             'def __pragma__ (): pass',
-        
+
             # Make __include__ known to the static checker
-            '__pragma__ (\'skip\')',            
-            '__new__ = __include__ = 0',    
+            '__pragma__ (\'skip\')',
+            '__new__ = __include__ = 0',
             '__pragma__ (\'noskip\')',
             ''
         ] if commandArgs.dcheck else []
         global nrOfExtraLines
         nrOfExtraLines = max (len (extraLines) - 1, 0)  # Last line only serves to force linefeed
         extraLines = '\n'.join (extraLines)
-        
+
 commandArgs = CommandArgs ()
-   
+
 def create (path, binary = False):
     for i in range (10):
         try:
             os.makedirs (os.path.dirname (path), exist_ok = True)
-            
+
             if binary:
                 return open (path, 'wb')
             else:
                 return open (path, 'w', encoding = 'utf-8')
-                
+
             if i > 0:
                 log (True, f'Created {path} at attempt {i + 1}')
-                
+
         except:
             time.sleep (0.5)
     else:
         raise Error (f'Failed to create {path}')
-        
+
 
 def tryRemove (filePath):
     try:
         os.remove (filePath)
     except:
         pass
-    
+
 def formatted (*args):  # args [0] is string, args [1 : ] are format params
     try:
         return str (args [0]) .format (*args [1 : ])
     except IndexError:  # Tuple index out of range in format tuple
         return ' '.join (args)
-   
+
 logFileName = 'transcrypt.log'  # ... Use envir.transpiler_name
-   
+
 try:
     os.remove (logFileName)
 except: # Assume logfile doesn't yet exist
     pass
-   
+
 def log (always, *args):
     if always or commandArgs.verbose:
         print (formatted (*args), end = '')
@@ -173,15 +173,15 @@ def log (always, *args):
             if commandArgs.dlog:
                 with open (logFileName, 'a') as logFile:
                     logFile.write (formatted (*args))
-         
+
         except: # Assume too early, commandArgs not yet set
             pass
-            
+
 program = None
 def setProgram (aProgram):
     global program
     program = aProgram
-         
+
 class Error (Exception):
     # First error encountered counts, for all fields, because it's closest to the cause of trouble
     # One error at a time, just like Python, clear and simple
@@ -191,14 +191,14 @@ class Error (Exception):
         self.lineNr = lineNr - nrOfExtraLines
         self.message = message
         # The name of the module and of its import trail is known from the import stack, so no need to pass it as a parameter
-        
-    def set (self, lineNr = 0, message = ''):          
+
+    def set (self, lineNr = 0, message = ''):
         if not self.lineNr:
             self.lineNr = lineNr - nrOfExtraLines
-            
+
         if not self.message:
             self.message = message
-            
+
     def __str__ (self):
         result = 'Error while compiling (offending file last):'
 
@@ -209,15 +209,15 @@ class Error (Exception):
             except:
                 sourcePath = '<unknown>'
             result += '\n\tFile \'{}\', line {}, at import of:'.format (sourcePath, importRecord [1])
-        
+
         # After that, report the module and line that caused the error
 #        result += '\n\tFile \'{}\', line {}, namely:'.format (str (program.importStack [-1][0] .sourcePath), self.lineNr)
         result += '\n\tFile \'{}\', line {}, namely:'.format (str (program.importStack [-1][0] .name), self.lineNr)
-        
+
         # And, lastly, report the error message
         result += '\n\t{}'.format (self.message)
         return result
-        
+
 def enhanceException (exception, **kwargs):
     # If not all required info, such as a line number, is available at the location where the exception was raised,
     # it is enhanced later on by adding this missing info at the earliest occasion
@@ -227,7 +227,7 @@ def enhanceException (exception, **kwargs):
         result = exception
     else:
         result = Error (**kwargs)
-    
+
     if commandArgs.dextex:
         print ('''
     Exception of class {0} enhanced at:
@@ -240,7 +240,7 @@ def enhanceException (exception, **kwargs):
     '''.format (exception.__class__, *inspect.stack () [1][1:-1], kwargs, result))
 
     raise result from None
-        
+
 def digestJavascript (code, symbols, mayStripComments, mayRemoveAnnotations, refuseIfAppearsMinified = False):
     '''
     - Honor ifdefs
@@ -250,24 +250,24 @@ def digestJavascript (code, symbols, mayStripComments, mayRemoveAnnotations, ref
 
     if refuseIfAppearsMinified and code [0] != '/':
         return None
-    
+
     stripComments = False
-        
+
     def stripSingleLineComments (line):
         pos = line.find ('//')
         return (line if pos < 0 else line [ : pos]) .rstrip ()
 
     passStack = []
 
-    def passable (targetLine):        
+    def passable (targetLine):
         # Has to count, since comments may be inside ifdefs
-        
+
         nonlocal stripComments
-        
+
         def __pragma__ (name, *args):   # Will be called below by executing the stripped line of source code
 
             nonlocal stripComments
-        
+
             if name == 'stripcomments':
                 stripComments = mayStripComments
             if name == 'ifdef':
@@ -296,47 +296,47 @@ def digestJavascript (code, symbols, mayStripComments, mayRemoveAnnotations, ref
             return False                # Skip line anyhow, independent of passStack
         else:
             return all (passStack)      # Skip line only if not in passing state according to passStack
-    
+
     passableLines = [line for line in code.split ('\n') if passable (line)]
-    
+
     if stripComments:
         passableLines = [commentlessLine for commentlessLine in [stripSingleLineComments (line) for line in passableLines] if commentlessLine]
-        
+
     result = Any (
         digestedCode = '\n'.join (passableLines),
         nrOfLines = len (passableLines),
         exportedNames = [],
         importedModuleNames = []
     )
-    
+
     namesPattern = re.compile ('({.*})')
     pathPattern = re.compile ('([\'|\"].*[\'|\"])')
     wordPattern = re.compile (r'[\w/*$]+')  # /S matches too much, e.g. { and }  ??? Is this OK in all cases? Scrutinize code below...
     for line in passableLines:
         words = wordPattern.findall (line)
-        
+
         if words:
             if mayRemoveAnnotations and words [0] == '/*':  # If line starts with an annotation
                 words = words [3 : ]                        # Remove the annotation before looking for export / import keywords
-                
-            if words:    
+
+            if words:
                 if words [0] == 'export':
                     # Deducing exported names from JavaScript is needed to facilitate * import by other modules
-                    
+
                     if words [1] in {'var', 'function'}:
                         # Export prefix:    "export var ... or export function ..."
-                        
+
                         result.exportedNames.append (words [2])
                     else:
-                        # Transit export:   "export {p, q, r, s};"  
-                        
+                        # Transit export:   "export {p, q, r, s};"
+
                         # Find exported names as "{p, q, r, s}"
                         match = namesPattern.search (line)
-                        
+
                         # Substitute to become "{'p', 'q', 'r', 's'}" and use that set to extend the exported names list
                         if match:
                             result.exportedNames.extend (eval (wordPattern.sub (lambda nameMatch: f'\'{nameMatch.group ()}\'', match.group (1))))
-                         
+
                 elif words [0] == 'import':
                     # Deducing imported modules from JavaScript is needed to provide the right modules to JavaScript-only modules
                     # They may have an explicit import list for unqualified access or an import * for qualified access
@@ -344,12 +344,12 @@ def digestJavascript (code, symbols, mayStripComments, mayRemoveAnnotations, ref
                     # It can be a path without extension, allowing both .py and .js files as imported modules
                     #
                     # - Unqualified import:   "import {p, q as Q, r, s as S} from '<relative module path>'"
-                    # - Qualified import:     "import * from '<relative module path>'"  
-                    
+                    # - Qualified import:     "import * from '<relative module path>'"
+
                     match = pathPattern.search (line)
                     if match:
                         result.importedModuleNames.append (eval (match.group (1)) [2:-3])
-                        
+
     return result
 
-    
+


### PR DESCRIPTION
This PR currently depends on a development version of aroberge/ideas - see https://github.com/aroberge/ideas/pull/42 for the latest version.

This adds HTML embedded in Python, between delimiters `>>|` and `|<<`.  HTML elements are converted into a function call to `el(element_name, attrs_dict, children_list)`.  So this function:

```
def some_html():
    return >>|
        <div class="div-class">
            Some Text
            <a href="http://google.com">
                A Link
            </a>
        </div>
    |<<
```

is rendered as:

```
def some_html():
    return el("div", {"class": "div-class"}, [
        "Some Text",
        el("a", {"href": "http://google.com"}, [
            "A Link"
        ])
    ])
```

The `el()` function is not provided and must be already available in the context where the HTML appears.  Its signature is intended to enable this use:

```
react = require("react")
el = react.createElement
```

I'm posting this PR to get feedback; if there is a possibility it will be merged, please say so and I will add some unit tests etc and get it into proper shape.  If there is no interest in this sort of PR, please let me know.

My apologies for a relatively large number of whitespace changes.  My editor regularised a number of line endings and removed whitespace at the end of lines.