### PR TITLE
Escape apostrophes in docstrings

### DIFF
--- a/transcrypt/modules/org/transcrypt/compiler.py
+++ b/transcrypt/modules/org/transcrypt/compiler.py
@@ -2061,7 +2061,7 @@ class Generator (ast.NodeVisitor):
         if self.allowDocAttribs:
             docString = ast.get_docstring (node)
             if docString:
-               self.emit (' .__setdoc__ (\'{}\')', docString.replace ('\n', '\\n '))
+               self.emit (' .__setdoc__ (\'{}\')', docString.replace ('\n', '\\n ').replace('\'', '\\\''))
 
         # Deal with data class var assigns, a flavor of special class var assigns
         if isDataClass: # Constructor + params have to be generated, no real class vars, just syntactically
@@ -2747,7 +2747,7 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
             if self.allowDocAttribs:
                 docString = ast.get_docstring (node)
                 if docString:
-                    self.emit (' .__setdoc__ (\'{}\')', docString.replace ('\n', '\\n '))
+                    self.emit (' .__setdoc__ (\'{}\')', docString.replace ('\n', '\\n ').replace('\'', '\\\''))
 
 
             if decorate:
@@ -3102,7 +3102,7 @@ return list (selfFields).''' + comparatorName + '''(list (otherFields));
 
         # Insert docstring at hoist location, further hoists are PRE(!)pended
         if self.allowDocAttribs and docString:
-            self.emit ('export var __doc__ = \'{}\';\n', docString.replace ('\n', '\\n'))
+            self.emit ('export var __doc__ = \'{}\';\n', docString.replace ('\n', '\\n').replace ('\'', '\\\''))
 
         '''
         Make the globals () function work as well as possible in conjunction with JavaScript 6 modules rather than closures


### PR DESCRIPTION
Fixes an issue that occurs when using the `-d` / `--docat` option, where apostrophes in docstrings do not get escaped.

<hr>

`__runtime__.py` contains one example of this:

https://github.com/TranscryptOrg/Transcrypt/blob/88af746d2d580a7aca9704db462eadf0a3ee868c/transcrypt/modules/org/transcrypt/__runtime__.py#L247-L255

Resulting in invalid syntax in the output JS:
<img width="824" alt="image" src="https://github.com/user-attachments/assets/8f0cdc5b-0d69-4c4a-8840-3c295ef72a5f">

